### PR TITLE
Added handling of the case where we're within a Tokio Runtime or not

### DIFF
--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -13,10 +13,14 @@
 use crate::{MessageFlag, UPClientZenoh, CB_RUNTIME};
 use async_trait::async_trait;
 use lazy_static::lazy_static;
-use std::sync::Mutex;
-use std::{sync::Arc, time::Duration};
-use tokio::runtime::Runtime;
-use tokio::{runtime::Handle, task};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::{
+    runtime::{Handle, Runtime},
+    task,
+};
 use up_rust::{
     ComparableListener, UAttributes, UAttributesValidators, UCode, UListener, UMessage,
     UMessageType, UStatus, UTransport, UUri,

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -12,7 +12,10 @@
  ********************************************************************************/
 use crate::{MessageFlag, UPClientZenoh, CB_RUNTIME};
 use async_trait::async_trait;
+use lazy_static::lazy_static;
+use std::sync::Mutex;
 use std::{sync::Arc, time::Duration};
+use tokio::runtime::Runtime;
 use tokio::{runtime::Handle, task};
 use up_rust::{
     ComparableListener, UAttributes, UAttributesValidators, UCode, UListener, UMessage,
@@ -24,20 +27,42 @@ use zenoh::{
     queryable::Query,
 };
 
+lazy_static! {
+    static ref TOKIO_RUNTIME: Mutex<Runtime> = Mutex::new(Runtime::new().unwrap());
+}
+
 #[inline]
 fn invoke_block_callback(listener: &Arc<dyn UListener>, resp_msg: Result<UMessage, &str>) {
     match resp_msg {
-        Ok(umsg) => {
-            task::block_in_place(|| {
-                Handle::current().block_on(listener.on_receive(umsg));
-            });
-        }
+        Ok(umsg) => match Handle::try_current() {
+            Ok(handle) => {
+                task::block_in_place(|| {
+                    handle.block_on(listener.on_receive(umsg));
+                });
+            }
+            Err(_) => {
+                TOKIO_RUNTIME
+                    .lock()
+                    .unwrap()
+                    .block_on(listener.on_receive(umsg));
+            }
+        },
         Err(err_msg) => {
             log::error!("{err_msg}");
-            task::block_in_place(|| {
-                Handle::current()
-                    .block_on(listener.on_error(UStatus::fail_with_code(UCode::INTERNAL, err_msg)));
-            });
+            match Handle::try_current() {
+                Ok(handle) => {
+                    task::block_in_place(|| {
+                        handle.block_on(
+                            listener.on_error(UStatus::fail_with_code(UCode::INTERNAL, err_msg)),
+                        );
+                    });
+                }
+                Err(_) => {
+                    TOKIO_RUNTIME.lock().unwrap().block_on(
+                        listener.on_error(UStatus::fail_with_code(UCode::INTERNAL, err_msg)),
+                    );
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# What

Added handling of the case where we're within a Tokio Runtime or not
* if we're within a Tokio Runtime use the current handle
* if not, use a dedicated Tokio Runtime we have (e.g. we're within an async-std executor)

# Why

To handle the current case / issue of trying to send a Request UMessage within a Zenoh Plugin on zenoh 0.11.0-rc3, which I _think_ still uses async-std. Therefore we need to ensure we use a dedicated Tokio Runtime in that case within up-transport-zenoh-rust.

With this change, we resolve [this issue](https://github.com/eclipse-uprotocol/up-streamer-rust/pull/17#:~:text=Issue%20with%20up%2Dtransport%2Dzenoh%2Drust%20assuming%20it%27s%20inside%20of%20a%20Tokio%20runtime%3F) pointed out on the up-linux-streamer-plugin PR:
> Issue with up-transport-zenoh-rust assuming it's inside of a Tokio runtime?