### PR TITLE
Move examples back to up-transport-zenoh-rust.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,6 +20,7 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "examples/**"
       - "Cargo.*"
       - ".github/**"
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,18 @@ cargo tarpaulin -o lcov -o html --output-dir target/tarpaulin
 
 ## Examples
 
-The examples of using up-transport-zenoh-rust can be found in [up-zenoh-example-rust](https://github.com/eclipse-uprotocol/up-zenoh-example-rust).
+The examples of up-transport-zenoh-rust can be found under examples folder.
+
+```shell
+# Publisher
+cargo run --example publisher
+# Subscriber
+cargo run --example subscriber
+# RPC Server
+cargo run --example rpc_server
+# RPC Client
+cargo run --example rpc_client
+```
 
 ## Note
 

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+use up_transport_zenoh::zenoh_config;
+
+#[allow(clippy::must_use_candidate, clippy::missing_panics_doc)]
+pub fn get_zenoh_config() -> zenoh_config::Config {
+    // Load the config from file path
+    // Config Examples: https://github.com/eclipse-zenoh/zenoh/blob/0.10.1-rc/DEFAULT_CONFIG.json5
+    // let mut zenoh_cfg = Config::from_file("./DEFAULT_CONFIG.json5").unwrap();
+
+    // Loat the default config struct
+    let mut zenoh_cfg = zenoh_config::Config::default();
+    // You can choose from Router, Peer, Client
+    zenoh_cfg
+        .set_mode(Some(zenoh_config::WhatAmI::Peer))
+        .unwrap();
+
+    zenoh_cfg
+}

--- a/examples/publisher.rs
+++ b/examples/publisher.rs
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+mod common;
+
+use std::str::FromStr;
+use tokio::time::{sleep, Duration};
+use up_rust::{UMessageBuilder, UPayloadFormat, UTransport, UUri};
+use up_transport_zenoh::UPClientZenoh;
+
+#[tokio::main]
+async fn main() {
+    // initiate logging
+    UPClientZenoh::try_init_log_from_env();
+
+    println!("uProtocol publisher example");
+    let publisher = UPClientZenoh::new(common::get_zenoh_config(), String::from("publisher"))
+        .await
+        .unwrap();
+
+    // create uuri
+    let uuri = UUri::from_str("//publisher/1/1/8001").unwrap();
+
+    let mut cnt: u64 = 0;
+    loop {
+        let data = format!("{cnt}");
+        let umessage = UMessageBuilder::publish(uuri.clone())
+            .build_with_payload(data.clone(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
+            .unwrap();
+        println!("Sending {data} to {uuri}...");
+        publisher.send(umessage).await.unwrap();
+        sleep(Duration::from_millis(1000)).await;
+        cnt += 1;
+    }
+}

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+mod common;
+
+use std::str::FromStr;
+use up_rust::{RpcClient, UMessageBuilder, UPayloadFormat, UUri};
+use up_transport_zenoh::UPClientZenoh;
+
+#[tokio::main]
+async fn main() {
+    // initiate logging
+    UPClientZenoh::try_init_log_from_env();
+
+    println!("uProtocol RPC client example");
+    let rpc_client = UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_client"))
+        .await
+        .unwrap();
+
+    // create uuri
+    let src_uuri = UUri::from_str("//rpc_client/1/1/0").unwrap();
+    let sink_uuri = UUri::from_str("//rpc_server/1/1/1").unwrap();
+
+    // create uPayload
+    let data = String::from("GetCurrentTime");
+    let umsg = UMessageBuilder::request(sink_uuri.clone(), src_uuri.clone(), 1000)
+        .build_with_payload(data, UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
+        .unwrap();
+
+    // invoke RPC method
+    println!("Send request from {src_uuri} to {sink_uuri}");
+    let result = rpc_client.invoke_method(sink_uuri, umsg).await;
+
+    // process the result
+    let payload = result.unwrap().payload.unwrap();
+    let value = payload.into_iter().map(|c| c as char).collect::<String>();
+    println!("Receive {value}");
+}

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -1,0 +1,101 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+mod common;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use std::{str::FromStr, sync::Arc};
+use tokio::{
+    runtime::Handle,
+    task,
+    time::{sleep, Duration},
+};
+use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UStatus, UTransport, UUri};
+use up_transport_zenoh::UPClientZenoh;
+
+struct RpcListener {
+    up_client: Arc<UPClientZenoh>,
+}
+impl RpcListener {
+    fn new(up_client: Arc<UPClientZenoh>) -> Self {
+        RpcListener { up_client }
+    }
+}
+#[async_trait]
+impl UListener for RpcListener {
+    async fn on_receive(&self, msg: UMessage) {
+        let UMessage {
+            attributes,
+            payload,
+            ..
+        } = msg;
+
+        // Build the payload to send back
+        let value = payload
+            .unwrap()
+            .into_iter()
+            .map(|c| c as char)
+            .collect::<String>();
+        let source = attributes.clone().unwrap().source.unwrap();
+        let sink = attributes.clone().unwrap().sink.unwrap();
+        println!("Receive {value} from {source} to {sink}");
+
+        // Send back result
+        let umessage = UMessageBuilder::response_for_request(&attributes)
+            .build_with_payload(
+                // Get current time
+                format!("{}", Utc::now()),
+                UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
+            )
+            .unwrap();
+        task::block_in_place(|| {
+            Handle::current()
+                .block_on(self.up_client.send(umessage))
+                .unwrap();
+        });
+    }
+    async fn on_error(&self, err: UStatus) {
+        panic!("Internal Error: {err:?}");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // initiate logging
+    UPClientZenoh::try_init_log_from_env();
+
+    println!("uProtocol RPC server example");
+    let rpc_server = Arc::new(
+        UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_server"))
+            .await
+            .unwrap(),
+    );
+
+    // create uuri
+    let src_uuri = UUri::from_str("//*/FFFF/FF/FFFF").unwrap();
+    let sink_uuri = UUri::from_str("//rpc_server/1/1/1").unwrap();
+
+    println!("Register the listener...");
+    rpc_server
+        .register_listener(
+            &src_uuri,
+            Some(&sink_uuri),
+            Arc::new(RpcListener::new(rpc_server.clone())),
+        )
+        .await
+        .unwrap();
+
+    loop {
+        sleep(Duration::from_millis(1000)).await;
+    }
+}

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+mod common;
+
+use async_trait::async_trait;
+use std::{str::FromStr, sync::Arc};
+use tokio::time::{sleep, Duration};
+use up_rust::{UListener, UMessage, UStatus, UTransport, UUri};
+use up_transport_zenoh::UPClientZenoh;
+
+struct SubscriberListener;
+#[async_trait]
+impl UListener for SubscriberListener {
+    async fn on_receive(&self, msg: UMessage) {
+        let payload = msg.payload.unwrap();
+        let value = payload.into_iter().map(|c| c as char).collect::<String>();
+        let uri = msg.attributes.unwrap().source.unwrap().to_string();
+        println!("Receiving {value} from {uri}");
+    }
+    async fn on_error(&self, err: UStatus) {
+        panic!("Internal Error: {err:?}");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // initiate logging
+    UPClientZenoh::try_init_log_from_env();
+
+    println!("uProtocol subscriber example");
+    let subscriber = UPClientZenoh::new(common::get_zenoh_config(), String::from("subscriber"))
+        .await
+        .unwrap();
+
+    // create uuri
+    let uuri = UUri::from_str("//publisher/1/1/8001").unwrap();
+
+    println!("Register the listener...");
+    subscriber
+        .register_listener(&uuri, None, Arc::new(SubscriberListener {}))
+        .await
+        .unwrap();
+
+    loop {
+        sleep(Duration::from_millis(1000)).await;
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/issues/46, we'll move the examples back