### PR TITLE
Update to the latest up-rust (Support L2 API)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.8.5"
 tokio = { version = "1.35.1", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "3a50104421a801d52e1d9c68979db54c013ce43d" }
+up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "a74c829d3e54ce09c7b85ee721be7e8ac703aac9" }
 zenoh = { version = "0.11.0-rc.3", features = ["unstable"]}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1.35.1", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 up-rust = "0.1.3"
-zenoh = { version = "0.11.0-rc.3", features = ["unstable"]}
+zenoh = { version = "0.11.0", features = ["unstable"]}
 
 [dev-dependencies]
 test-case = { version = "3.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.8.5"
 tokio = { version = "1.35.1", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "cf5af235f4fa267bdacf7e313347708c64a11ac1" }
+up-rust = "0.1.3"
 zenoh = { version = "0.11.0-rc.3", features = ["unstable"]}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.8.5"
 tokio = { version = "1.35.1", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "a74c829d3e54ce09c7b85ee721be7e8ac703aac9" }
+up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "cf5af235f4fa267bdacf7e313347708c64a11ac1" }
 zenoh = { version = "0.11.0-rc.3", features = ["unstable"]}
 
 [dev-dependencies]

--- a/examples/l2_rpc_client.rs
+++ b/examples/l2_rpc_client.rs
@@ -17,7 +17,7 @@ use up_rust::{
     communication::{CallOptions, RpcClient, UPayload},
     LocalUriProvider, UPayloadFormat, UPriority, UUri, UUID,
 };
-use up_transport_zenoh::{UPClientZenoh, ZenohRpcClient};
+use up_transport_zenoh::{UPTransportZenoh, ZenohRpcClient};
 
 pub struct MyUriProvider {
     uuri: UUri,
@@ -41,11 +41,11 @@ impl LocalUriProvider for MyUriProvider {
 #[tokio::main]
 async fn main() {
     // initiate logging
-    UPClientZenoh::try_init_log_from_env();
+    UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol RPC client example");
     let zenoh_transport = Arc::new(
-        UPClientZenoh::new(common::get_zenoh_config(), "rpc_client")
+        UPTransportZenoh::new(common::get_zenoh_config(), "rpc_client")
             .await
             .unwrap(),
     );

--- a/examples/l2_rpc_client.rs
+++ b/examples/l2_rpc_client.rs
@@ -1,0 +1,82 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+mod common;
+
+use std::{str::FromStr, sync::Arc};
+use up_rust::{
+    communication::{CallOptions, RpcClient, UPayload},
+    LocalUriProvider, UPayloadFormat, UPriority, UUri, UUID,
+};
+use up_transport_zenoh::{UPClientZenoh, ZenohRpcClient};
+
+pub struct MyUriProvider {
+    uuri: UUri,
+}
+impl LocalUriProvider for MyUriProvider {
+    fn get_authority(&self) -> String {
+        self.uuri.authority_name.clone()
+    }
+
+    fn get_resource_uri(&self, resource_id: u16) -> UUri {
+        let mut uuri = self.uuri.clone();
+        uuri.resource_id = u32::from(resource_id);
+        uuri
+    }
+
+    fn get_source_uri(&self) -> UUri {
+        self.uuri.clone()
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // initiate logging
+    UPClientZenoh::try_init_log_from_env();
+
+    println!("uProtocol RPC client example");
+    let zenoh_transport = Arc::new(
+        UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_client"))
+            .await
+            .unwrap(),
+    );
+    let uri_provider = Arc::new(MyUriProvider {
+        uuri: UUri::from_str("//rpc_client/1/1/0").unwrap(),
+    });
+    let rpc_client = Arc::new(ZenohRpcClient::new(zenoh_transport, uri_provider.clone()));
+
+    let sink_uuri = UUri::from_str("//rpc_server/1/1/1").unwrap();
+
+    // create uPayload and send request
+    let data = String::from("GetCurrentTime");
+    let payload = UPayload::new(data.into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT);
+    let call_options = CallOptions::for_rpc_request(
+        5_000,
+        Some(UUID::build()),
+        Some("my_token".to_string()),
+        Some(UPriority::UPRIORITY_CS6),
+    );
+    println!(
+        "Sending request from {} to {}",
+        uri_provider.get_source_uri(),
+        sink_uuri
+    );
+    let result = rpc_client
+        .invoke_method(sink_uuri, call_options, Some(payload))
+        .await
+        .unwrap();
+
+    // process the result
+    let payload = result.unwrap().payload();
+    let value = payload.into_iter().map(|c| c as char).collect::<String>();
+    println!("Receive {value}");
+}

--- a/examples/l2_rpc_client.rs
+++ b/examples/l2_rpc_client.rs
@@ -30,10 +30,7 @@ async fn main() {
             .await
             .unwrap(),
     );
-    let rpc_client = Arc::new(ZenohRpcClient::new(
-        zenoh_transport.clone(),
-        zenoh_transport.clone(),
-    ));
+    let rpc_client = Arc::new(ZenohRpcClient::new(zenoh_transport.clone()));
 
     let sink_uuri = UUri::from_str("//rpc_server/1/1/1").unwrap();
 

--- a/examples/l2_rpc_client.rs
+++ b/examples/l2_rpc_client.rs
@@ -45,7 +45,7 @@ async fn main() {
 
     println!("uProtocol RPC client example");
     let zenoh_transport = Arc::new(
-        UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_client"))
+        UPClientZenoh::new(common::get_zenoh_config(), "rpc_client")
             .await
             .unwrap(),
     );

--- a/examples/publisher.rs
+++ b/examples/publisher.rs
@@ -12,9 +12,8 @@
  ********************************************************************************/
 mod common;
 
-use std::str::FromStr;
 use tokio::time::{sleep, Duration};
-use up_rust::{UMessageBuilder, UPayloadFormat, UTransport, UUri};
+use up_rust::{LocalUriProvider, UMessageBuilder, UPayloadFormat, UTransport};
 use up_transport_zenoh::UPTransportZenoh;
 
 #[tokio::main]
@@ -23,12 +22,12 @@ async fn main() {
     UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol publisher example");
-    let publisher = UPTransportZenoh::new(common::get_zenoh_config(), "publisher")
+    let publisher = UPTransportZenoh::new(common::get_zenoh_config(), "//publisher/1/1/0")
         .await
         .unwrap();
 
     // create uuri
-    let uuri = UUri::from_str("//publisher/1/1/8001").unwrap();
+    let uuri = publisher.get_resource_uri(0x8001);
 
     let mut cnt: u64 = 0;
     loop {

--- a/examples/publisher.rs
+++ b/examples/publisher.rs
@@ -15,15 +15,15 @@ mod common;
 use std::str::FromStr;
 use tokio::time::{sleep, Duration};
 use up_rust::{UMessageBuilder, UPayloadFormat, UTransport, UUri};
-use up_transport_zenoh::UPClientZenoh;
+use up_transport_zenoh::UPTransportZenoh;
 
 #[tokio::main]
 async fn main() {
     // initiate logging
-    UPClientZenoh::try_init_log_from_env();
+    UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol publisher example");
-    let publisher = UPClientZenoh::new(common::get_zenoh_config(), "publisher")
+    let publisher = UPTransportZenoh::new(common::get_zenoh_config(), "publisher")
         .await
         .unwrap();
 

--- a/examples/publisher.rs
+++ b/examples/publisher.rs
@@ -23,7 +23,7 @@ async fn main() {
     UPClientZenoh::try_init_log_from_env();
 
     println!("uProtocol publisher example");
-    let publisher = UPClientZenoh::new(common::get_zenoh_config(), String::from("publisher"))
+    let publisher = UPClientZenoh::new(common::get_zenoh_config(), "publisher")
         .await
         .unwrap();
 

--- a/examples/publisher.rs
+++ b/examples/publisher.rs
@@ -36,7 +36,7 @@ async fn main() {
         let umessage = UMessageBuilder::publish(uuri.clone())
             .build_with_payload(data.clone(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
             .unwrap();
-        println!("Sending {data} to {uuri}...");
+        println!("Publishing {data} from {uuri}...");
         publisher.send(umessage).await.unwrap();
         sleep(Duration::from_millis(1000)).await;
         cnt += 1;

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -70,7 +70,7 @@ async fn main() {
     let umsg = UMessageBuilder::request(sink_uuri.clone(), src_uuri.clone(), 1000)
         .build_with_payload(data, UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
         .unwrap();
-    println!("Send request from {src_uuri} to {sink_uuri}");
+    println!("Sending request from {src_uuri} to {sink_uuri}");
     rpc_client.send(umsg).await.unwrap();
 
     while resp_listener.response.lock().unwrap().is_none() {

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -13,7 +13,7 @@
 mod common;
 
 use std::str::FromStr;
-use up_rust::{RpcClient, UMessageBuilder, UPayloadFormat, UUri};
+use up_rust::{UMessageBuilder, UPayloadFormat, UUri};
 use up_transport_zenoh::UPClientZenoh;
 
 #[tokio::main]
@@ -22,7 +22,7 @@ async fn main() {
     UPClientZenoh::try_init_log_from_env();
 
     println!("uProtocol RPC client example");
-    let rpc_client = UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_client"))
+    let _rpc_client = UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_client"))
         .await
         .unwrap();
 
@@ -32,16 +32,16 @@ async fn main() {
 
     // create uPayload
     let data = String::from("GetCurrentTime");
-    let umsg = UMessageBuilder::request(sink_uuri.clone(), src_uuri.clone(), 1000)
+    let _umsg = UMessageBuilder::request(sink_uuri.clone(), src_uuri.clone(), 1000)
         .build_with_payload(data, UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
         .unwrap();
 
-    // invoke RPC method
-    println!("Send request from {src_uuri} to {sink_uuri}");
-    let result = rpc_client.invoke_method(sink_uuri, umsg).await;
+    //// invoke RPC method
+    //println!("Send request from {src_uuri} to {sink_uuri}");
+    //let result = rpc_client.invoke_method(sink_uuri, umsg).await;
 
-    // process the result
-    let payload = result.unwrap().payload.unwrap();
-    let value = payload.into_iter().map(|c| c as char).collect::<String>();
-    println!("Receive {value}");
+    //// process the result
+    //let payload = result.unwrap().payload.unwrap();
+    //let value = payload.into_iter().map(|c| c as char).collect::<String>();
+    //println!("Receive {value}");
 }

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -50,7 +50,7 @@ async fn main() {
     UPClientZenoh::try_init_log_from_env();
 
     println!("uProtocol RPC client example");
-    let rpc_client = UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_client"))
+    let rpc_client = UPClientZenoh::new(common::get_zenoh_config(), "rpc_client")
         .await
         .unwrap();
 

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -18,7 +18,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tokio::time::{sleep, Duration};
-use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
+use up_rust::{
+    LocalUriProvider, UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri,
+};
 use up_transport_zenoh::UPTransportZenoh;
 
 // ResponseListener
@@ -50,12 +52,12 @@ async fn main() {
     UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol RPC client example");
-    let rpc_client = UPTransportZenoh::new(common::get_zenoh_config(), "rpc_client")
+    let rpc_client = UPTransportZenoh::new(common::get_zenoh_config(), "//rpc_client/1/1/0")
         .await
         .unwrap();
 
     // create uuri
-    let src_uuri = UUri::from_str("//rpc_client/1/1/0").unwrap();
+    let src_uuri = rpc_client.get_source_uri();
     let sink_uuri = UUri::from_str("//rpc_server/1/1/1").unwrap();
 
     // register response callback

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use tokio::time::{sleep, Duration};
 use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
-use up_transport_zenoh::UPClientZenoh;
+use up_transport_zenoh::UPTransportZenoh;
 
 // ResponseListener
 struct ResponseListener {
@@ -47,10 +47,10 @@ impl UListener for ResponseListener {
 #[tokio::main]
 async fn main() {
     // initiate logging
-    UPClientZenoh::try_init_log_from_env();
+    UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol RPC client example");
-    let rpc_client = UPClientZenoh::new(common::get_zenoh_config(), "rpc_client")
+    let rpc_client = UPTransportZenoh::new(common::get_zenoh_config(), "rpc_client")
         .await
         .unwrap();
 

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -21,14 +21,14 @@ use tokio::{
     time::{sleep, Duration},
 };
 use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
-use up_transport_zenoh::UPClientZenoh;
+use up_transport_zenoh::UPTransportZenoh;
 
 struct RpcListener {
-    up_client: Arc<UPClientZenoh>,
+    up_transport: Arc<UPTransportZenoh>,
 }
 impl RpcListener {
-    fn new(up_client: Arc<UPClientZenoh>) -> Self {
-        RpcListener { up_client }
+    fn new(up_transport: Arc<UPTransportZenoh>) -> Self {
+        RpcListener { up_transport }
     }
 }
 #[async_trait]
@@ -60,7 +60,7 @@ impl UListener for RpcListener {
             .unwrap();
         task::block_in_place(|| {
             Handle::current()
-                .block_on(self.up_client.send(umessage))
+                .block_on(self.up_transport.send(umessage))
                 .unwrap();
         });
     }
@@ -69,11 +69,11 @@ impl UListener for RpcListener {
 #[tokio::main]
 async fn main() {
     // initiate logging
-    UPClientZenoh::try_init_log_from_env();
+    UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol RPC server example");
     let rpc_server = Arc::new(
-        UPClientZenoh::new(common::get_zenoh_config(), "rpc_server")
+        UPTransportZenoh::new(common::get_zenoh_config(), "rpc_server")
             .await
             .unwrap(),
     );

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -73,7 +73,7 @@ async fn main() {
 
     println!("uProtocol RPC server example");
     let rpc_server = Arc::new(
-        UPClientZenoh::new(common::get_zenoh_config(), String::from("rpc_server"))
+        UPClientZenoh::new(common::get_zenoh_config(), "rpc_server")
             .await
             .unwrap(),
     );

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -20,7 +20,9 @@ use tokio::{
     task,
     time::{sleep, Duration},
 };
-use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
+use up_rust::{
+    LocalUriProvider, UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri,
+};
 use up_transport_zenoh::UPTransportZenoh;
 
 struct RpcListener {
@@ -73,14 +75,14 @@ async fn main() {
 
     println!("uProtocol RPC server example");
     let rpc_server = Arc::new(
-        UPTransportZenoh::new(common::get_zenoh_config(), "rpc_server")
+        UPTransportZenoh::new(common::get_zenoh_config(), "//rpc_server/1/1/0")
             .await
             .unwrap(),
     );
 
     // create uuri
-    let src_uuri = UUri::from_str("//*/FFFF/FF/FFFF").unwrap();
-    let sink_uuri = UUri::from_str("//rpc_server/1/1/1").unwrap();
+    let src_uuri = UUri::from_str("//*/FFFF/FF/0").unwrap();
+    let sink_uuri = rpc_server.get_resource_uri(1);
 
     println!("Register the listener...");
     rpc_server

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -20,7 +20,7 @@ use tokio::{
     task,
     time::{sleep, Duration},
 };
-use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UStatus, UTransport, UUri};
+use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
 use up_transport_zenoh::UPClientZenoh;
 
 struct RpcListener {
@@ -63,9 +63,6 @@ impl UListener for RpcListener {
                 .block_on(self.up_client.send(umessage))
                 .unwrap();
         });
-    }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
     }
 }
 

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -48,7 +48,7 @@ impl UListener for RpcListener {
             .collect::<String>();
         let source = attributes.clone().unwrap().source.unwrap();
         let sink = attributes.clone().unwrap().sink.unwrap();
-        println!("Receive {value} from {source} to {sink}");
+        println!("Receiving {value} from {source} to {sink}");
 
         // Send back result
         let umessage = UMessageBuilder::response_for_request(&attributes)

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -15,7 +15,7 @@ mod common;
 use async_trait::async_trait;
 use std::{str::FromStr, sync::Arc};
 use tokio::time::{sleep, Duration};
-use up_rust::{UListener, UMessage, UStatus, UTransport, UUri};
+use up_rust::{UListener, UMessage, UTransport, UUri};
 use up_transport_zenoh::UPClientZenoh;
 
 struct SubscriberListener;
@@ -26,9 +26,6 @@ impl UListener for SubscriberListener {
         let value = payload.into_iter().map(|c| c as char).collect::<String>();
         let uri = msg.attributes.unwrap().source.unwrap().to_string();
         println!("Receiving {value} from {uri}");
-    }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
     }
 }
 

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use std::{str::FromStr, sync::Arc};
 use tokio::time::{sleep, Duration};
 use up_rust::{UListener, UMessage, UTransport, UUri};
-use up_transport_zenoh::UPClientZenoh;
+use up_transport_zenoh::UPTransportZenoh;
 
 struct SubscriberListener;
 #[async_trait]
@@ -32,10 +32,10 @@ impl UListener for SubscriberListener {
 #[tokio::main]
 async fn main() {
     // initiate logging
-    UPClientZenoh::try_init_log_from_env();
+    UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol subscriber example");
-    let subscriber = UPClientZenoh::new(common::get_zenoh_config(), "subscriber")
+    let subscriber = UPTransportZenoh::new(common::get_zenoh_config(), "subscriber")
         .await
         .unwrap();
 

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -35,7 +35,7 @@ async fn main() {
     UPClientZenoh::try_init_log_from_env();
 
     println!("uProtocol subscriber example");
-    let subscriber = UPClientZenoh::new(common::get_zenoh_config(), String::from("subscriber"))
+    let subscriber = UPClientZenoh::new(common::get_zenoh_config(), "subscriber")
         .await
         .unwrap();
 

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -35,7 +35,7 @@ async fn main() {
     UPTransportZenoh::try_init_log_from_env();
 
     println!("uProtocol subscriber example");
-    let subscriber = UPTransportZenoh::new(common::get_zenoh_config(), "subscriber")
+    let subscriber = UPTransportZenoh::new(common::get_zenoh_config(), "//subscriber/2/1/0")
         .await
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+pub mod rpc;
 pub mod utransport;
+
+pub use rpc::ZenohRpcClient;
 
 use bitmask_enum::bitmask;
 use protobuf::Message;
@@ -20,10 +23,7 @@ use std::{
 };
 use tokio::runtime::Runtime;
 use tracing::error;
-use up_rust::{
-    uri::{WILDCARD_ENTITY_ID, WILDCARD_ENTITY_VERSION, WILDCARD_RESOURCE_ID},
-    ComparableListener, UAttributes, UCode, UListener, UPriority, UStatus, UUri,
-};
+use up_rust::{ComparableListener, UAttributes, UCode, UListener, UPriority, UStatus, UUri};
 // Re-export Zenoh config
 pub use zenoh::config as zenoh_config;
 use zenoh::{
@@ -167,19 +167,19 @@ impl UPClientZenoh {
             &uri.authority_name
         };
         // ue_id
-        let ue_id = if uri.ue_id == WILDCARD_ENTITY_ID {
+        let ue_id = if uri.has_wildcard_entity_id() {
             "*".to_string()
         } else {
             format!("{:X}", uri.ue_id)
         };
         // ue_version_major
-        let ue_version_major = if uri.ue_version_major == WILDCARD_ENTITY_VERSION {
+        let ue_version_major = if uri.has_wildcard_version() {
             "*".to_string()
         } else {
             format!("{:X}", uri.ue_version_major)
         };
         // resource_id
-        let resource_id = if uri.resource_id == WILDCARD_RESOURCE_ID {
+        let resource_id = if uri.has_wildcard_resource_id() {
             "*".to_string()
         } else {
             format!("{:X}", uri.resource_id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,27 +371,28 @@ mod tests {
     #[test_case("//192.168.1.100/10AB/3/0", Some("//192.168.1.101/20EF/4/B"), Ok(MessageFlag::Request); "Request Message")]
     #[test_case("//192.168.1.101/20EF/4/B", Some("//192.168.1.100/10AB/3/0"), Ok(MessageFlag::Response); "Response Message")]
     #[test_case("//*/FFFF/FF/FFFF", Some("//192.168.1.100/10AB/3/0"), Ok(MessageFlag::Notification | MessageFlag::Response); "Listen to Notification and Response Message")]
-    #[test_case("//*/FFFF/FF/FFFF", Some("//192.168.1.101/20EF/4/B"), Err(UStatus::fail_with_code(UCode::INTERNAL, "Wrong combination of source UUri and sink UUri")); "Impossible scenario 1")]
-    #[test_case("//192.168.1.100/10AB/3/0", Some("//*/FFFF/FF/FFFF"), Err(UStatus::fail_with_code(UCode::INTERNAL, "Wrong combination of source UUri and sink UUri")); "Impossible scenario 2")]
-    #[test_case("//192.168.1.101/20EF/4/B", Some("//*/FFFF/FF/FFFF"), Err(UStatus::fail_with_code(UCode::INTERNAL, "Wrong combination of source UUri and sink UUri")); "Impossible scenario 3")]
-    #[test_case("//192.168.1.100/10AB/3/80CD", Some("//*/FFFF/FF/FFFF"), Err(UStatus::fail_with_code(UCode::INTERNAL, "Wrong combination of source UUri and sink UUri")); "Impossible scenario 4")]
+    #[test_case("//*/FFFF/FF/FFFF", Some("//192.168.1.101/20EF/4/B"), Err(UCode::INTERNAL); "Impossible scenario 1")]
+    #[test_case("//192.168.1.100/10AB/3/0", Some("//*/FFFF/FF/FFFF"), Err(UCode::INTERNAL); "Impossible scenario 2")]
+    #[test_case("//192.168.1.101/20EF/4/B", Some("//*/FFFF/FF/FFFF"), Err(UCode::INTERNAL); "Impossible scenario 3")]
+    #[test_case("//192.168.1.100/10AB/3/80CD", Some("//*/FFFF/FF/FFFF"), Err(UCode::INTERNAL); "Impossible scenario 4")]
     #[test_case("//*/FFFF/FF/FFFF", Some("//[::1]/FFFF/FF/FFFF"), Ok(MessageFlag::Notification | MessageFlag::Request | MessageFlag::Response); "All messages to a device")]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_get_listener_message_type(
         src_uri: &str,
         sink_uri: Option<&str>,
-        result: Result<MessageFlag, UStatus>,
+        result: Result<MessageFlag, UCode>,
     ) {
         let src = UUri::from_str(src_uri).unwrap();
         if let Some(uri) = sink_uri {
             let dst = UUri::from_str(uri).unwrap();
             assert_eq!(
-                UPTransportZenoh::get_listener_message_type(&src, Some(&dst)),
+                UPTransportZenoh::get_listener_message_type(&src, Some(&dst))
+                    .map_err(|e| e.get_code()),
                 result
             );
         } else {
             assert_eq!(
-                UPTransportZenoh::get_listener_message_type(&src, None),
+                UPTransportZenoh::get_listener_message_type(&src, None).map_err(|e| e.get_code()),
                 result
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-pub mod rpc;
 pub mod utransport;
 
 use bitmask_enum::bitmask;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,10 @@ use std::{
 };
 use tokio::runtime::Runtime;
 use tracing::error;
-use up_rust::{ComparableListener, UAttributes, UCode, UListener, UPriority, UStatus, UUri};
+use up_rust::{
+    uri::{WILDCARD_ENTITY_ID, WILDCARD_ENTITY_VERSION, WILDCARD_RESOURCE_ID},
+    ComparableListener, UAttributes, UCode, UListener, UPriority, UStatus, UUri,
+};
 // Re-export Zenoh config
 pub use zenoh::config as zenoh_config;
 use zenoh::{
@@ -30,15 +33,6 @@ use zenoh::{
     sample::{Attachment, AttachmentBuilder},
     subscriber::Subscriber,
 };
-
-// CY_TODO: Whether to expose from up_rust or not
-const _WILDCARD_AUTHORITY: &str = "*";
-const WILDCARD_ENTITY_ID: u32 = 0x0000_FFFF;
-const WILDCARD_ENTITY_VERSION: u32 = 0x0000_00FF;
-const WILDCARD_RESOURCE_ID: u32 = 0x0000_FFFF;
-
-const _RESOURCE_ID_RESPONSE: u32 = 0;
-const _RESOURCE_ID_MIN_EVENT: u32 = 0x8000;
 
 const UATTRIBUTE_VERSION: u8 = 1;
 const THREAD_NUM: usize = 10;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl UPTransportZenoh {
     ///
     /// # Arguments
     ///
-    /// * `config` - Zenoh configuration. You can refer to [here](https://github.com/eclipse-zenoh/zenoh/blob/0.11.0-rc.3/DEFAULT_CONFIG.json5) for more configuration details.
+    /// * `config` - Zenoh configuration. You can refer to [here](https://github.com/eclipse-zenoh/zenoh/blob/0.11.0/DEFAULT_CONFIG.json5) for more configuration details.
     /// * `authority_name` - The authority name. We need it to generate Zenoh key since authority might be omitted in `UUri`.
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,14 +89,14 @@ impl UPClientZenoh {
     /// #[tokio::main]
     /// # async fn main() {
     /// use up_transport_zenoh::{zenoh_config, UPClientZenoh};
-    /// let upclient = UPClientZenoh::new(zenoh_config::Config::default(), String::from("MyAuthName"))
+    /// let upclient = UPClientZenoh::new(zenoh_config::Config::default(), "MyAuthName")
     ///     .await
     ///     .unwrap();
     /// # }
     /// ```
     pub async fn new(
         config: zenoh_config::Config,
-        authority_name: String,
+        authority_name: impl Into<String>,
     ) -> Result<UPClientZenoh, UStatus> {
         // Create Zenoh session
         let Ok(session) = zenoh::open(config).res().await else {
@@ -111,7 +111,7 @@ impl UPClientZenoh {
             queryable_map: Arc::new(Mutex::new(HashMap::new())),
             query_map: Arc::new(Mutex::new(HashMap::new())),
             rpc_callback_map: Arc::new(Mutex::new(HashMap::new())),
-            authority_name,
+            authority_name: authority_name.into(),
         })
     }
 
@@ -324,12 +324,9 @@ mod tests {
     #[test_case("//*/FFFF/FF/FFFF", Some("//[::1]/FFFF/FF/FFFF"), "up/*/*/*/*/[::1]/*/*/*"; "Receive all messages to a device")]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_to_zenoh_key_string(src_uri: &str, sink_uri: Option<&str>, zenoh_key: &str) {
-        let up_client_zenoh = UPClientZenoh::new(
-            zenoh_config::Config::default(),
-            String::from("192.168.1.100"),
-        )
-        .await
-        .unwrap();
+        let up_client_zenoh = UPClientZenoh::new(zenoh_config::Config::default(), "192.168.1.100")
+            .await
+            .unwrap();
         let src = UUri::from_str(src_uri).unwrap();
         if let Some(sink) = sink_uri {
             let sink = UUri::from_str(sink).unwrap();

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-use crate::UPClientZenoh;
+use crate::UPTransportZenoh;
 use async_trait::async_trait;
 use std::{string::ToString, sync::Arc, time::Duration};
 use tracing::error;
@@ -22,7 +22,7 @@ use up_rust::{
 use zenoh::prelude::r#async::*;
 
 pub struct ZenohRpcClient {
-    transport: Arc<UPClientZenoh>,
+    transport: Arc<UPTransportZenoh>,
     uri_provider: Arc<dyn LocalUriProvider>,
 }
 impl ZenohRpcClient {
@@ -32,7 +32,7 @@ impl ZenohRpcClient {
     ///
     /// * `transport` - The Zenoh uProtocol Transport Layer.
     /// * `uri_provider` - The helper for creating URIs that represent local resources.
-    pub fn new(transport: Arc<UPClientZenoh>, uri_provider: Arc<dyn LocalUriProvider>) -> Self {
+    pub fn new(transport: Arc<UPTransportZenoh>, uri_provider: Arc<dyn LocalUriProvider>) -> Self {
         ZenohRpcClient {
             transport,
             uri_provider,
@@ -80,7 +80,7 @@ impl RpcClient for ZenohRpcClient {
             .to_zenoh_key_string(&source_uri, Some(&method));
 
         // Put UAttributes into Zenoh user attachment
-        let Ok(attachment) = UPClientZenoh::uattributes_to_attachment(&attributes) else {
+        let Ok(attachment) = UPTransportZenoh::uattributes_to_attachment(&attributes) else {
             let msg = "Unable to transform UAttributes to user attachment in Zenoh".to_string();
             error!("{msg}");
             return Err(ServiceInvocationError::Internal(msg));

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -14,13 +14,21 @@ use crate::UPClientZenoh;
 use async_trait::async_trait;
 use std::{string::ToString, time::Duration};
 use tracing::error;
-use up_rust::{RpcClient, RpcClientResult, UAttributesError, UMessage, UMessageError, UUri};
+use up_rust::{
+    communication::{CallOptions, RpcClient, ServiceInvocationError, UPayload},
+    UAttributesError, UMessage, UMessageError, UUri,
+};
 use zenoh::prelude::r#async::*;
 
 #[async_trait]
 impl RpcClient for UPClientZenoh {
-    // CY_TODO: Should remove method in the future
-    async fn invoke_method(&self, _method: UUri, request: UMessage) -> RpcClientResult {
+    async fn invoke_method(
+        &self,
+        method: UUri,
+        call_options: CallOptions,
+        payload: Option<UPayload>,
+    ) -> Result<Option<UPayload>, ServiceInvocationError> {
+        //async fn invoke_method(&self, _method: UUri, request: UMessage) -> RpcClientResult {
         // Get Zenoh key
         let source = *request.attributes.source.0.clone().ok_or_else(|| {
             let msg = "attributes.source should not be empty".to_string();

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -23,7 +23,6 @@ use zenoh::prelude::r#async::*;
 
 pub struct ZenohRpcClient {
     transport: Arc<UPTransportZenoh>,
-    uri_provider: Arc<dyn LocalUriProvider>,
 }
 impl ZenohRpcClient {
     /// Creates a new RPC client for the Zenoh transport.
@@ -31,12 +30,8 @@ impl ZenohRpcClient {
     /// # Arguments
     ///
     /// * `transport` - The Zenoh uProtocol Transport Layer.
-    /// * `uri_provider` - The helper for creating URIs that represent local resources.
-    pub fn new(transport: Arc<UPTransportZenoh>, uri_provider: Arc<dyn LocalUriProvider>) -> Self {
-        ZenohRpcClient {
-            transport,
-            uri_provider,
-        }
+    pub fn new(transport: Arc<UPTransportZenoh>) -> Self {
+        ZenohRpcClient { transport }
     }
 }
 
@@ -57,14 +52,14 @@ impl RpcClient for ZenohRpcClient {
         }
 
         // Get source UUri
-        let source_uri = self.uri_provider.get_source_uri();
+        let source_uri = self.transport.get_source_uri();
 
         let attributes = UAttributes {
             type_: UMessageType::UMESSAGE_TYPE_REQUEST.into(),
             id: Some(call_options.message_id().unwrap_or_else(UUID::build)).into(),
             priority: call_options
                 .priority()
-                .unwrap_or(UPriority::UPRIORITY_UNSPECIFIED)
+                .unwrap_or(UPriority::UPRIORITY_CS4)
                 .into(),
             source: Some(source_uri.clone()).into(),
             sink: Some(method.clone()).into(),

--- a/src/uri_provider.rs
+++ b/src/uri_provider.rs
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use crate::UPTransportZenoh;
+use up_rust::{LocalUriProvider, UUri};
+
+impl LocalUriProvider for UPTransportZenoh {
+    fn get_authority(&self) -> String {
+        self.uri.authority_name.clone()
+    }
+
+    fn get_resource_uri(&self, resource_id: u16) -> UUri {
+        let mut uri = self.get_source_uri();
+        uri.resource_id = u32::from(resource_id);
+        uri
+    }
+
+    fn get_source_uri(&self) -> UUri {
+        self.uri.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use std::str::FromStr;
+    use test_case::test_case;
+    use up_rust::UUri;
+
+    #[test_case("//vehicle1/AABB/7/0", "vehicle1", 0x8001, UUri::from_str("//vehicle1/AABB/7/0").unwrap(); "Publish/Notification Resource ID")]
+    #[test_case("//192.168.0.1/A1B2/1/0", "192.168.0.1", 0xA, UUri::from_str("//192.168.0.1/A1B2/1/0").unwrap(); "RPC Resource ID")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_local_uri_provider(
+        uri: &str,
+        authority: &str,
+        resource_id: u16,
+        source_uri: UUri,
+    ) {
+        let up_transport_zenoh = UPTransportZenoh::new(zenoh_config::Config::default(), uri)
+            .await
+            .unwrap();
+        assert_eq!(up_transport_zenoh.get_authority(), authority);
+        assert_eq!(
+            up_transport_zenoh.get_resource_uri(resource_id).resource_id,
+            u32::from(resource_id)
+        );
+        assert_eq!(up_transport_zenoh.get_source_uri(), source_uri);
+    }
+}

--- a/tests/blocking_callback.rs
+++ b/tests/blocking_callback.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
 use test_case::test_case;
 use tokio::time::{sleep, Duration};
-use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UStatus, UTransport, UUri};
+use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
 
 struct DelayListener {
     recv_data: Arc<Mutex<String>>,
@@ -41,9 +41,6 @@ impl UListener for DelayListener {
             sleep(Duration::from_millis(3000)).await;
         }
         *self.recv_data.lock().unwrap() = value;
-    }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
     }
 }
 

--- a/tests/blocking_callback.rs
+++ b/tests/blocking_callback.rs
@@ -51,16 +51,16 @@ async fn test_blocking_user_callback(pub_uuri: &UUri) {
     test_lib::before_test();
 
     // Initialization
-    let upclient_send = test_lib::create_up_client_zenoh("nonblock_pub")
+    let uptransport_send = test_lib::create_up_transport_zenoh("nonblock_pub")
         .await
         .unwrap();
-    let upclient_recv = test_lib::create_up_client_zenoh("nonblock_sub")
+    let uptransport_recv = test_lib::create_up_transport_zenoh("nonblock_sub")
         .await
         .unwrap();
 
     // Register the listener
     let pub_listener = Arc::new(DelayListener::new());
-    upclient_recv
+    uptransport_recv
         .register_listener(pub_uuri, None, pub_listener.clone())
         .await
         .unwrap();
@@ -74,8 +74,8 @@ async fn test_blocking_user_callback(pub_uuri: &UUri) {
     let umsg1 = UMessageBuilder::publish(pub_uuri.clone())
         .build_with_payload("Pub 1", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
         .unwrap();
-    upclient_send.send(umsg0).await.unwrap();
-    upclient_send.send(umsg1).await.unwrap();
+    uptransport_send.send(umsg0).await.unwrap();
+    uptransport_send.send(umsg1).await.unwrap();
 
     // Receive the data in reverse order due to the delay time
     // Waiting for the subscriber to receive 2nd data
@@ -86,7 +86,7 @@ async fn test_blocking_user_callback(pub_uuri: &UUri) {
     assert_eq!(pub_listener.get_recv_data(), "Pub 0".to_string());
 
     // Cleanup
-    upclient_recv
+    uptransport_recv
         .unregister_listener(pub_uuri, None, pub_listener)
         .await
         .unwrap();

--- a/tests/l2_rpc.rs
+++ b/tests/l2_rpc.rs
@@ -1,0 +1,114 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+pub mod test_lib;
+
+use std::{str::FromStr, sync::Arc};
+use tokio::time::{sleep, Duration};
+use up_rust::{
+    communication::{
+        CallOptions, InMemoryRpcServer, RequestHandler, RpcClient, RpcServer,
+        ServiceInvocationError, UPayload,
+    },
+    LocalUriProvider, UPayloadFormat, UUri,
+};
+use up_transport_zenoh::ZenohRpcClient;
+
+const METHOD_RESOURCE_ID: u16 = 0x00a0;
+
+struct ExampleHandler {
+    request_data: String,
+    response_data: String,
+}
+impl ExampleHandler {
+    pub fn new(request_data: String, response_data: String) -> Self {
+        ExampleHandler {
+            request_data,
+            response_data,
+        }
+    }
+}
+#[async_trait::async_trait]
+impl RequestHandler for ExampleHandler {
+    async fn invoke_method(
+        &self,
+        _resource_id: u16,
+        request_payload: Option<UPayload>,
+    ) -> Result<Option<UPayload>, ServiceInvocationError> {
+        let payload = request_payload.unwrap().payload();
+        let data = payload.into_iter().map(|c| c as char).collect::<String>();
+        // compare the request data
+        assert_eq!(data, self.request_data);
+        // return
+        let payload = UPayload::new(
+            self.response_data.clone().into(),
+            UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
+        );
+        Ok(Some(payload))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_l2_rpc() {
+    test_lib::before_test();
+
+    // Initialization
+    let request_data = String::from("This is the request data");
+    let response_data = String::from("This is the response data");
+    let uptransport_server = Arc::new(
+        test_lib::create_up_transport_zenoh("//l2_responder/2/1/0")
+            .await
+            .unwrap(),
+    );
+    let uptransport_client = Arc::new(
+        test_lib::create_up_transport_zenoh("//l2_requester/1/1/0")
+            .await
+            .unwrap(),
+    );
+
+    // Create L2 RPC server
+    let rpc_server = InMemoryRpcServer::new(uptransport_server.clone(), uptransport_server.clone());
+    let example_handler = Arc::new(ExampleHandler::new(
+        request_data.clone(),
+        response_data.clone(),
+    ));
+    // CY_TODO: Verify the what kind of resource_id we can listen to
+    rpc_server
+        .register_endpoint(
+            Some(&UUri::from_str("//*/FFFF/FF/0").unwrap()),
+            METHOD_RESOURCE_ID,
+            example_handler.clone(),
+        )
+        .await
+        .unwrap();
+    // Need some time for queryable to run
+    sleep(Duration::from_millis(1000)).await;
+
+    // Create L2 RPC client
+    let rpc_client = Arc::new(ZenohRpcClient::new(uptransport_client.clone()));
+
+    let payload = UPayload::new(request_data.into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT);
+    let call_options = CallOptions::for_rpc_request(5_000, None, None, None);
+    let result = rpc_client
+        .invoke_method(
+            uptransport_server.get_resource_uri(METHOD_RESOURCE_ID),
+            call_options,
+            Some(payload),
+        )
+        .await
+        .unwrap();
+
+    // Process the result
+    let payload = result.unwrap().payload();
+    let value = payload.into_iter().map(|c| c as char).collect::<String>();
+    assert_eq!(response_data, value);
+}

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
 use test_case::test_case;
 use tokio::time::{sleep, Duration};
-use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UStatus, UTransport, UUri};
+use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
 
 struct PublishNotificationListener {
     recv_data: Arc<Mutex<String>>,
@@ -37,9 +37,6 @@ impl UListener for PublishNotificationListener {
         let data = msg.payload.unwrap();
         let value = data.into_iter().map(|c| c as char).collect::<String>();
         *self.recv_data.lock().unwrap() = value;
-    }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
     }
 }
 

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -16,13 +16,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use test_case::test_case;
-use up_rust::{UListener, UMessage, UStatus, UTransport, UUri};
+use up_rust::{UListener, UMessage, UTransport, UUri};
 
 struct FooListener;
 #[async_trait]
 impl UListener for FooListener {
     async fn on_receive(&self, _msg: UMessage) {}
-    async fn on_error(&self, _err: UStatus) {}
 }
 
 #[test_case(&test_lib::new_uuri("src", 1, 1, 0x8000), None; "Listen to Publish")]

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -27,7 +27,7 @@ impl UListener for FooListener {
 #[test_case(&test_lib::new_uuri("src", 1, 1, 0x8000), None; "Listen to Publish")]
 #[test_case(&test_lib::new_uuri("*", 0xFFFF, 0xFF, 0xFFFF), Some(&test_lib::new_uuri("dst", 2, 1, 0)); "Listen to Notification")]
 #[test_case(&test_lib::new_uuri("src", 1, 1, 0x8000), Some(&test_lib::new_uuri("dst", 2, 1, 0)); "Listen to specific Notification")]
-#[test_case(&test_lib::new_uuri("*", 0xFFFF, 0xFF, 0xFFFF), Some(&test_lib::new_uuri("dst", 2, 1, 0x0001)); "Listen to Request")]
+#[test_case(&test_lib::new_uuri("*", 0xFFFF, 0xFF, 0), Some(&test_lib::new_uuri("dst", 2, 1, 0x0001)); "Listen to Request")]
 #[test_case(&test_lib::new_uuri("src", 1, 1, 0), Some(&test_lib::new_uuri("dst", 2, 1, 0x0001)); "Listen to specific Request")]
 #[test_case(&test_lib::new_uuri("*", 0xFFFF, 0xFF, 0xFFFF), Some(&test_lib::new_uuri("dst", 2, 1, 0)); "Listen to Response")]
 #[test_case(&test_lib::new_uuri("src", 1, 1, 0x0001), Some(&test_lib::new_uuri("dst", 2, 1, 0)); "Listen to specific Response")]

--- a/tests/register.rs
+++ b/tests/register.rs
@@ -38,23 +38,25 @@ async fn test_register_and_unregister(source_filter: &UUri, sink_filter: Option<
     test_lib::before_test();
 
     // Initialization
-    let upclient = test_lib::create_up_client_zenoh("myvehicle").await.unwrap();
+    let uptransport = test_lib::create_up_transport_zenoh("myvehicle")
+        .await
+        .unwrap();
     let foo_listener = Arc::new(FooListener);
 
     // Register the listener
-    upclient
+    uptransport
         .register_listener(source_filter, sink_filter, foo_listener.clone())
         .await
         .unwrap();
 
     // Able to ungister
-    upclient
+    uptransport
         .unregister_listener(source_filter, sink_filter, foo_listener.clone())
         .await
         .unwrap();
 
     // Unable to ungister
-    let result = upclient
+    let result = uptransport
         .unregister_listener(source_filter, sink_filter, foo_listener.clone())
         .await;
     assert!(result.is_err());

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -20,9 +20,7 @@ use tokio::{
     task,
     time::{sleep, Duration},
 };
-use up_rust::{
-    RpcClient, UListener, UMessage, UMessageBuilder, UPayloadFormat, UStatus, UTransport, UUri,
-};
+use up_rust::{UListener, UMessage, UMessageBuilder, UPayloadFormat, UTransport, UUri};
 use up_transport_zenoh::UPClientZenoh;
 
 // RequestListener
@@ -68,9 +66,6 @@ impl UListener for RequestListener {
                 .unwrap();
         });
     }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
-    }
 }
 
 // ResponseListener
@@ -98,9 +93,6 @@ impl UListener for ResponseListener {
             .map(|c| c as char)
             .collect::<String>();
         *self.response_data.lock().unwrap() = value;
-    }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
     }
 }
 
@@ -136,21 +128,21 @@ async fn test_rpc_server_client(
     sleep(Duration::from_millis(1000)).await;
 
     // Send Request with invoke_method
-    {
-        let result = upclient_client
-            .invoke_method(
-                (*sink_uuri).clone(),
-                UMessageBuilder::request((*sink_uuri).clone(), (*src_uuri).clone(), 1000)
-                    .build_with_payload(request_data.clone(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
-                    .unwrap(),
-            )
-            .await;
+    //{
+    //    let result = upclient_client
+    //        .invoke_method(
+    //            (*sink_uuri).clone(),
+    //            UMessageBuilder::request((*sink_uuri).clone(), (*src_uuri).clone(), 1000)
+    //                .build_with_payload(request_data.clone(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
+    //                .unwrap(),
+    //        )
+    //        .await;
 
-        // Process the result
-        let payload = result.unwrap().payload.unwrap();
-        let value = payload.into_iter().map(|c| c as char).collect::<String>();
-        assert_eq!(response_data.clone(), value);
-    }
+    //    // Process the result
+    //    let payload = result.unwrap().payload.unwrap();
+    //    let value = payload.into_iter().map(|c| c as char).collect::<String>();
+    //    assert_eq!(response_data.clone(), value);
+    //}
 
     // Send Request with send
     {

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -120,7 +120,7 @@ impl LocalUriProvider for MyUriProvider {
     }
 }
 
-#[test_case(&test_lib::new_uuri("requester", 1, 1, 0), &test_lib::new_uuri("responder", 2, 1, 1), &test_lib::new_uuri("*", 0xFFFF, 0xFF, 0xFFFF), Some(&test_lib::new_uuri("responder", 2, 1, 1)); "Any source UUri")]
+#[test_case(&test_lib::new_uuri("requester", 1, 1, 0), &test_lib::new_uuri("responder", 2, 1, 1), &test_lib::new_uuri("*", 0xFFFF, 0xFF, 0), Some(&test_lib::new_uuri("responder", 2, 1, 1)); "Any source UUri")]
 #[test_case(&test_lib::new_uuri("requester", 1, 1, 0), &test_lib::new_uuri("responder", 2, 1, 1), &test_lib::new_uuri("requester", 1, 1, 0), Some(&test_lib::new_uuri("responder", 2, 1, 1)); "Specific source UUri")]
 #[test_case(&test_lib::new_uuri("ustreamer_requester", 1, 1, 0), &test_lib::new_uuri("ustreamer_responder", 2, 1, 1), &test_lib::new_uuri("ustreamer_requester", 0xFFFF, 0xFF, 0xFFFF), Some(&test_lib::new_uuri("*", 0xFFFF, 0xFF, 0xFFFF)); "uStreamer case for RPC")]
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -149,10 +149,7 @@ async fn test_rpc_server_client(
 
     // Send Request with ZenohRpcClient (L2 API)
     {
-        let rpc_client = Arc::new(ZenohRpcClient::new(
-            uptransport_client.clone(),
-            uptransport_client.clone(),
-        ));
+        let rpc_client = Arc::new(ZenohRpcClient::new(uptransport_client.clone()));
 
         let payload = UPayload::new(
             request_data.clone().into(),

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 use std::sync::Once;
-use up_rust::{UStatus, UUri};
+use up_rust::UStatus;
 use up_transport_zenoh::{zenoh_config, UPTransportZenoh};
 
 static INIT: Once = Once::new();
@@ -22,17 +22,6 @@ pub fn before_test() {
 
 /// # Errors
 /// Will return `Err` if unable to create `UPTransportZenoh`
-pub async fn create_up_transport_zenoh(uauthority: &str) -> Result<UPTransportZenoh, UStatus> {
-    UPTransportZenoh::new(zenoh_config::Config::default(), uauthority).await
-}
-
-#[allow(clippy::must_use_candidate)]
-pub fn new_uuri(authority: &str, ue_id: u32, ue_version_major: u8, resource_id: u16) -> UUri {
-    UUri {
-        authority_name: authority.to_string(),
-        ue_id,
-        ue_version_major: ue_version_major.into(),
-        resource_id: resource_id.into(),
-        ..Default::default()
-    }
+pub async fn create_up_transport_zenoh(uri: &str) -> Result<UPTransportZenoh, UStatus> {
+    UPTransportZenoh::new(zenoh_config::Config::default(), uri).await
 }

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -23,7 +23,7 @@ pub fn before_test() {
 /// # Errors
 /// Will return `Err` if unable to create `UPClientZenoh`
 pub async fn create_up_client_zenoh(uauthority: &str) -> Result<UPClientZenoh, UStatus> {
-    UPClientZenoh::new(zenoh_config::Config::default(), uauthority.to_string()).await
+    UPClientZenoh::new(zenoh_config::Config::default(), uauthority).await
 }
 
 #[allow(clippy::must_use_candidate)]

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -12,18 +12,18 @@
  ********************************************************************************/
 use std::sync::Once;
 use up_rust::{UStatus, UUri};
-use up_transport_zenoh::{zenoh_config, UPClientZenoh};
+use up_transport_zenoh::{zenoh_config, UPTransportZenoh};
 
 static INIT: Once = Once::new();
 
 pub fn before_test() {
-    INIT.call_once(UPClientZenoh::try_init_log_from_env);
+    INIT.call_once(UPTransportZenoh::try_init_log_from_env);
 }
 
 /// # Errors
-/// Will return `Err` if unable to create `UPClientZenoh`
-pub async fn create_up_client_zenoh(uauthority: &str) -> Result<UPClientZenoh, UStatus> {
-    UPClientZenoh::new(zenoh_config::Config::default(), uauthority).await
+/// Will return `Err` if unable to create `UPTransportZenoh`
+pub async fn create_up_transport_zenoh(uauthority: &str) -> Result<UPTransportZenoh, UStatus> {
+    UPTransportZenoh::new(zenoh_config::Config::default(), uauthority).await
 }
 
 #[allow(clippy::must_use_candidate)]

--- a/tests/ustreamer.rs
+++ b/tests/ustreamer.rs
@@ -23,7 +23,7 @@ use tokio::{
     time::{sleep, Duration},
 };
 use up_rust::{
-    UListener, UMessage, UMessageBuilder, UMessageType, UPayloadFormat, UStatus, UTransport, UUri,
+    UListener, UMessage, UMessageBuilder, UMessageType, UPayloadFormat, UTransport, UUri,
 };
 use up_transport_zenoh::UPClientZenoh;
 
@@ -90,9 +90,6 @@ impl UListener for UStreamerListener {
             }
         };
     }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
-    }
 }
 
 // ResponseListener
@@ -120,9 +117,6 @@ impl UListener for ResponseListener {
             .map(|c| c as char)
             .collect::<String>();
         *self.response_data.lock().unwrap() = value;
-    }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
     }
 }
 
@@ -155,9 +149,6 @@ impl UListener for RequestListener {
                 .block_on(self.up_client.send(umessage))
                 .unwrap();
         });
-    }
-    async fn on_error(&self, err: UStatus) {
-        panic!("Internal Error: {err:?}");
     }
 }
 


### PR DESCRIPTION
The PR is to use the latest up-rust, including the following update:

1. remove `on_error` in UListener
2. Support ZenohRpcClient (New way for L2 API)
