### PR TITLE
Fix the Rust toolchain version at 1.74.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "up-transport-zenoh"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-zenoh-rust"
-rust-version = "1.74.0"
+rust-version = "1.74.1"
 version = "0.1.0"
 
 [lints.clippy]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.74.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,9 +184,9 @@ impl UPTransportZenoh {
     fn uri_to_zenoh_key(&self, uri: &UUri) -> String {
         // authority_name
         let authority = if uri.authority_name.is_empty() {
-            &self.get_authority()
+            self.get_authority()
         } else {
-            &uri.authority_name
+            uri.authority_name.clone()
         };
         // ue_id
         let ue_id = if uri.has_wildcard_entity_id() {


### PR DESCRIPTION
Fix the nightly msrv [CI error](https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/actions/runs/10104128685/job/27942593912).
Also specify the Rust toolchain version to avoid the error in the future.