### PR TITLE
Use the correct Rust version to fix MSRV issue.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 name = "up-transport-zenoh"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-zenoh-rust"
-rust-version = "1.74.1"
+rust-version = "1.75.0"
 version = "0.1.1"
 
 [lints.clippy]


### PR DESCRIPTION
Now the CI kept failing. This is because the mismatch Rust tool version.