### PR TITLE
Remove obsolete dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,15 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,15 +1030,6 @@ name = "iter-read"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1655,38 +1637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -2873,12 +2823,8 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "crossbeam-channel",
  "lazy_static",
- "prost",
- "prost-types",
  "protobuf",
- "rand",
  "test-case",
  "tokio",
  "tracing",
@@ -3289,7 +3235,7 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "git-version",
- "itertools 0.13.0",
+ "itertools",
  "lazy_static",
  "once_cell",
  "ordered-float",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,7 @@
 [package]
 description = "Zenoh Rust Transport library implementation of the Eclipse uProtocol"
 edition = "2021"
-include = [
-    "/src/*",
-    "/examples/*",
-    "/Cargo.toml",
-    "/README.md",
-    "/config/*",
-]
+include = ["/src/*", "/examples/*", "/Cargo.toml", "/README.md", "/config/*"]
 keywords = ["uProtocol", "SDK", "communication", "Zenoh"]
 license = "Apache-2.0"
 name = "up-transport-zenoh"
@@ -41,21 +35,17 @@ anyhow = "1.0.75"
 async-trait = "0.1"
 bitmask-enum = "2.2.4"
 bytes = "1.6.1"
-chrono = "0.4.31"
-clap = { version = "4.4.11", features = ["derive"] }
-crossbeam-channel = "0.5.12"
 lazy_static = "1.4.0"
-prost = "0.12"
-prost-types = "0.12"
 protobuf = { version = "3.3" }
-rand = "0.8.5"
 tokio = { version = "1.35.1", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 up-rust = "0.1.5"
-zenoh = { version = "1.0.0-alpha.6", features = ["unstable", "internal"]}
+zenoh = { version = "1.0.0-alpha.6", features = ["unstable", "internal"] }
 
 [dev-dependencies]
+chrono = "0.4.31"
+clap = { version = "4.4.11", features = ["derive"] }
 test-case = { version = "3.3" }
 
 [profile.release]


### PR DESCRIPTION
Removed crates from Cargo.toml which are not used anywhere in the code.
Also moved deps which are required for examples only to dev-dependencies block.