### PR TITLE
[#78] Support passing UUri into constructors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ use bitmask_enum::bitmask;
 use protobuf::Message;
 use std::{
     collections::HashMap,
-    str::FromStr,
     sync::{Arc, Mutex},
 };
 use tokio::runtime::Runtime;
@@ -75,7 +74,7 @@ pub struct UPTransportZenoh {
     // Save the callback for RPC response
     rpc_callback_map: RpcCallbackMap,
     // URI
-    uri: UUri,
+    local_uri: UUri,
 }
 
 impl UPTransportZenoh {
@@ -103,7 +102,7 @@ impl UPTransportZenoh {
     /// ```
     pub async fn new(
         config: zenoh_config::Config,
-        uri: impl Into<String>,
+        uri: impl TryInto<UUri>,
     ) -> Result<UPTransportZenoh, UStatus> {
         // Create Zenoh session
         let Ok(session) = zenoh::open(config).await else {
@@ -125,7 +124,7 @@ impl UPTransportZenoh {
     /// Will return `Err` if unable to create `UPTransportZenoh`
     pub async fn new_with_runtime(
         runtime: ZRuntime,
-        uri: impl Into<String>,
+        uri: impl TryInto<UUri>,
     ) -> Result<UPTransportZenoh, UStatus> {
         let Ok(session) = zenoh::session::init(runtime).await else {
             let msg = "Unable to open Zenoh session".to_string();
@@ -137,22 +136,22 @@ impl UPTransportZenoh {
 
     fn init_with_session(
         session: Session,
-        uri: impl Into<String>,
+        uri: impl TryInto<UUri>,
     ) -> Result<UPTransportZenoh, UStatus> {
         // From String to UUri
-        let uri = UUri::from_str(&uri.into()).map_err(|_| {
-            let msg = "Unable to transform the uri to UUri".to_string();
+        let local_uri: UUri = uri.try_into().map_err(|_| {
+            let msg = "invalid local UUri".to_string();
             error!("{msg}");
             UStatus::fail_with_code(UCode::INVALID_ARGUMENT, msg)
         })?;
         // Need to make sure the authority is always non-empty
-        if uri.has_empty_authority() {
+        if local_uri.has_empty_authority() {
             let msg = "Empty authority is not allowed".to_string();
             error!("{msg}");
             return Err(UStatus::fail_with_code(UCode::INVALID_ARGUMENT, msg));
         }
         // Make sure the resource ID is always 0
-        if uri.resource_id != 0 {
+        if local_uri.resource_id != 0 {
             let msg = "Resource ID should always be 0".to_string();
             error!("{msg}");
             return Err(UStatus::fail_with_code(UCode::INVALID_ARGUMENT, msg));
@@ -164,7 +163,7 @@ impl UPTransportZenoh {
             queryable_map: Arc::new(Mutex::new(HashMap::new())),
             query_map: Arc::new(Mutex::new(HashMap::new())),
             rpc_callback_map: Arc::new(Mutex::new(HashMap::new())),
-            uri,
+            local_uri,
         })
     }
 
@@ -338,12 +337,13 @@ mod tests {
     use test_case::test_case;
     use up_rust::UUri;
 
-    #[test_case("//vehicle1/AABB/7/0", true; "succeeds with valid UUri")]
-    #[test_case("This is not UUri", false; "fails with invalid UUri")]
-    #[test_case("/AABB/7/0", false; "fails with empty UAuthority")]
-    #[test_case("//vehicle1/AABB/7/1", false; "fails with non-zero resource ID")]
+    #[test_case("//vehicle1/AABB/7/0", true; "succeeds for valid URI")]
+    #[test_case(UUri::try_from_parts("vehicle1", 0xAABB, 0x07, 0x00).unwrap(), true; "succeeds for valid UUri")]
+    #[test_case("This is not UUri", false; "fails for invalid URI")]
+    #[test_case("/AABB/7/0", false; "fails for empty UAuthority")]
+    #[test_case("//vehicle1/AABB/7/1", false; "fails for non-zero resource ID")]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_new_up_transport_zenoh(uri: &str, expected_result: bool) {
+    async fn test_new_up_transport_zenoh(uri: impl TryInto<UUri>, expected_result: bool) {
         let up_transport_zenoh = UPTransportZenoh::new(zenoh_config::Config::default(), uri).await;
         assert_eq!(up_transport_zenoh.is_ok(), expected_result);
     }

--- a/src/uri_provider.rs
+++ b/src/uri_provider.rs
@@ -16,7 +16,7 @@ use up_rust::{LocalUriProvider, UUri};
 
 impl LocalUriProvider for UPTransportZenoh {
     fn get_authority(&self) -> String {
-        self.uri.authority_name.clone()
+        self.local_uri.authority_name.clone()
     }
 
     fn get_resource_uri(&self, resource_id: u16) -> UUri {
@@ -26,7 +26,7 @@ impl LocalUriProvider for UPTransportZenoh {
     }
 
     fn get_source_uri(&self) -> UUri {
-        self.uri.clone()
+        self.local_uri.clone()
     }
 }
 


### PR DESCRIPTION
The functions for creating a new UPTransportZenoh have been changed
to accept TryInto<UUri> which allows clients to pass in either
strings or UUri structs.