### PR TITLE
Pin to the older msrv version.

### DIFF
--- a/.github/workflows/verify-msrv.yaml
+++ b/.github/workflows/verify-msrv.yaml
@@ -32,5 +32,5 @@ jobs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
     - name: check MSRV
       run: |
-        cargo install cargo-msrv --version 0.15.1
+        cargo install cargo-msrv
         cargo msrv verify

--- a/.github/workflows/verify-msrv.yaml
+++ b/.github/workflows/verify-msrv.yaml
@@ -32,5 +32,5 @@ jobs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
     - name: check MSRV
       run: |
-        cargo install cargo-msrv
-        cargo msrv --verify
+        cargo install cargo-msrv --version 0.15.1
+        cargo msrv verify

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.75.0"


### PR DESCRIPTION
Fix the CI failure
https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/actions/runs/11265771929/job/31328151458

If we use msrv 0.16.x, it needs at least Rust 1.78.0. I guess it will be good to support the minimum version we need.
Therefore, I decide to fix at 0.15.1.