### PR TITLE
Avoid using zenoh-unstable in the examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,6 +2613,7 @@ dependencies = [
  "clap",
  "lazy_static",
  "protobuf",
+ "serde_json",
  "test-case",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ async-trait = "0.1"
 bytes = "1.6.1"
 lazy_static = "1.4.0"
 protobuf = { version = "3.3" }
+serde_json = "1.0.128"
 tokio = { version = "1.35.1", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 use clap::Parser;
+use serde_json::json;
 use up_transport_zenoh::zenoh_config;
 
 #[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -20,15 +21,16 @@ pub enum WhatAmIType {
     Router,
 }
 
-#[cfg(not(feature = "zenoh-unstable"))]
-#[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]
-pub struct Args {
-    #[arg(short, long)]
-    /// A configuration file.
-    config: Option<String>,
+impl WhatAmIType {
+    const fn to_str(self) -> &'static str {
+        match self {
+            Self::Peer => "peer",
+            Self::Client => "client",
+            Self::Router => "router",
+        }
+    }
 }
 
-#[cfg(feature = "zenoh-unstable")]
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Args {
     #[arg(short, long)]
@@ -53,49 +55,37 @@ pub fn get_zenoh_config() -> zenoh_config::Config {
     let args = Args::parse();
 
     // Load the config from file path
-    #[allow(unused_mut)]
     let mut zenoh_cfg = match &args.config {
         Some(path) => zenoh_config::Config::from_file(path).unwrap(),
         None => zenoh_config::Config::default(),
     };
 
-    #[cfg(feature = "zenoh-unstable")]
-    {
-        // You can choose from Router, Peer, Client
-        match args.mode {
-            Some(WhatAmIType::Peer) => zenoh_cfg.set_mode(Some(zenoh::config::WhatAmI::Peer)),
-            Some(WhatAmIType::Client) => zenoh_cfg.set_mode(Some(zenoh::config::WhatAmI::Client)),
-            Some(WhatAmIType::Router) => zenoh_cfg.set_mode(Some(zenoh::config::WhatAmI::Router)),
-            None => Ok(None),
-        }
-        .unwrap();
+    // You can choose from Router, Peer, Client
+    if let Some(mode) = args.mode {
+        zenoh_cfg
+            .insert_json5("mode", &json!(mode.to_str()).to_string())
+            .unwrap();
+    }
 
-        // Set connection address
-        if !args.connect.is_empty() {
-            zenoh_cfg
-                .connect
-                .endpoints
-                .set(args.connect.iter().map(|v| v.parse().unwrap()).collect())
-                .unwrap();
-        }
+    // Set connection address
+    if !args.connect.is_empty() {
+        zenoh_cfg
+            .insert_json5("connect/endpoints", &json!(args.connect).to_string())
+            .unwrap();
+    }
 
-        // Set listener address
-        if !args.listen.is_empty() {
-            zenoh_cfg
-                .listen
-                .endpoints
-                .set(args.listen.iter().map(|v| v.parse().unwrap()).collect())
-                .unwrap();
-        }
+    // Set listener address
+    if !args.listen.is_empty() {
+        zenoh_cfg
+            .insert_json5("listen/endpoints", &json!(args.listen).to_string())
+            .unwrap();
+    }
 
-        // Set multicast configuration
-        if args.no_multicast_scouting {
-            zenoh_cfg
-                .scouting
-                .multicast
-                .set_enabled(Some(false))
-                .unwrap();
-        }
+    // Set multicast configuration
+    if args.no_multicast_scouting {
+        zenoh_cfg
+            .insert_json5("scouting/multicast/enabled", &json!(false).to_string())
+            .unwrap();
     }
 
     zenoh_cfg


### PR DESCRIPTION
I just found `insert_json5` is a better way in examples code to avoid using unstable configuration API.