### PR TITLE
Bump to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "up-transport-zenoh"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "up-transport-zenoh"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-zenoh-rust"
 rust-version = "1.75.0"
-version = "0.3.1"
+version = "0.4.0"
 
 [lints.clippy]
 all = "deny"


### PR DESCRIPTION
Need to wait for https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/pull/93 to be merged.