### PR TITLE
Bump to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "up-transport-zenoh"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "up-transport-zenoh"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-zenoh-rust"
 rust-version = "1.76"
-version = "0.4.0"
+version = "0.5.0"
 
 [lints.clippy]
 all = "deny"


### PR DESCRIPTION
Since we have a breaking change on https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/pull/101, it would be better to release a new minor version.