### PR TITLE
Upgrade to ring 0.17.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,9 +2068,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3022,6 +3022,7 @@ dependencies = [
  "hashbrown 0.15.2",
  "lazy_static",
  "protobuf",
+ "ring",
  "rustls",
  "serde_json",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ bytes = "1.6.1"
 hashbrown = { version = "0.15.2" }
 lazy_static = "1.4.0"
 protobuf = { version = "3.3" }
+# explicitly depend on 0.17.13 to include fix for https://rustsec.org/advisories/RUSTSEC-2025-0009
+ring = { version = "0.17.13" }
 # explicitly depend on 0.23.18 to include fix for https://rustsec.org/advisories/RUSTSEC-2024-0399
 rustls = { version = "0.23.18" }
 serde_json = "1.0.128"

--- a/deny.toml
+++ b/deny.toml
@@ -34,9 +34,9 @@ private = { ignore = true }
 unused-allowed-license = "allow"
 
 [[licenses.clarify]]
-crate = "ring@0.17.9"
+crate = "ring@0.17.13"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+license-files = [{ path = "LICENSE", hash = 0x70ac5d83 }]
 
 [bans]
 multiple-versions = "deny"


### PR DESCRIPTION
This fixes https://rustsec.org/advisories/RUSTSEC-2025-0009