### PR TITLE
Bump to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "up-transport-zenoh"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "up-transport-zenoh"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-transport-zenoh-rust"
 rust-version = "1.82"
-version = "0.5.0"
+version = "0.6.0"
 
 [lints.clippy]
 all = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ pedantic = "deny"
 [dependencies]
 anyhow = "1.0.75"
 async-trait = "0.1"
-bytes = "1.6.1"
+bytes = "1.10.1"
 # explicitly depend on 0.15.2 to include fix for https://rustsec.org/advisories/RUSTSEC-2024-0402
 hashbrown = { version = "0.15.2" }
 lazy_static = "1.4.0"


### PR DESCRIPTION
Upgrade `up-transport-zenoh-rust` to include ring fix and apply `up-rust` update