### PR TITLE
Remove the dependency of requirements-tracing.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,20 +59,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # TODO: Disable the OFT CI for the time being.
+      #       We will enable it after https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/issues/103
       # Requirements Tracing report - we later need the download_url output of the upload step
-      - name: Download requirements tracing report
-        uses: actions/download-artifact@v4
-        with:
-          name: tracing-report-html
-          path: dist/tracing/
-      - name: Upload requirements tracing report to release
-        uses: svenstaro/upload-release-action@v2
-        id: upload_requirements_tracing_report
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/tracing/*
-          file_glob: true
-          tag: ${{ github.ref }}
+      #- name: Download requirements tracing report
+      #  uses: actions/download-artifact@v4
+      #  with:
+      #    name: tracing-report-html
+      #    path: dist/tracing/
+      #- name: Upload requirements tracing report to release
+      #  uses: svenstaro/upload-release-action@v2
+      #  id: upload_requirements_tracing_report
+      #  with:
+      #    repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #    file: dist/tracing/*
+      #    file_glob: true
+      #    tag: ${{ github.ref }}
 
       # Test report - we later need the download_url output of the upload step
       - name: Download test report
@@ -138,7 +140,10 @@ jobs:
           release_url: ${{ steps.latest_release_info.outputs.html_url }}
           artifacts_readme: ${{ steps.upload_readme.outputs.browser_download_url }}
           artifacts_requirements: ${{ steps.upload_up_spec.outputs.browser_download_url }}
-          artifacts_testing: ${{ steps.upload_test_report.outputs.browser_download_url }},${{ steps.upload_test_coverage.outputs.browser_download_url }},${{ steps.upload_requirements_tracing_report.outputs.browser_download_url }}
+          # TODO: Disable the OFT CI for the time being.
+          #       We will enable it after https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/issues/103
+          #artifacts_testing: ${{ steps.upload_test_report.outputs.browser_download_url }},${{ steps.upload_test_coverage.outputs.browser_download_url }},${{ steps.upload_requirements_tracing_report.outputs.browser_download_url }}
+          artifacts_testing: ${{ steps.upload_test_report.outputs.browser_download_url }},${{ steps.upload_test_coverage.outputs.browser_download_url }}
 
       - name: Upload manifest to release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,9 @@ jobs:
       - check
       - check-msrv
       - coverage
-      - requirements-tracing
+      # TODO: Disable the OFT CI for the time being.
+      #       We will enable it after https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/issues/103
+      #- requirements-tracing
     permissions: write-all
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Forgot to remove the dependency in https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/pull/110

My bad. @sophokles73 Would you mind reviewing this again? Hopefully, I didn't miss anything this time...