### PR TITLE
Get the submodule (up-spec).

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: "recursive"
     - uses: dtolnay/rust-toolchain@master
       with: 
         toolchain: ${{ env.RUST_TOOLCHAIN }}
@@ -59,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
       - uses: dtolnay/rust-toolchain@master
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
@@ -71,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
       - uses: dtolnay/rust-toolchain@master
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
@@ -86,6 +92,8 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
       - uses: dtolnay/rust-toolchain@master
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
@@ -101,6 +109,8 @@ jobs:
       NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
       - uses: dtolnay/rust-toolchain@master
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
@@ -126,6 +136,8 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
       - uses: dtolnay/rust-toolchain@master
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,8 @@ jobs:
     permissions: write-all
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
 
       # TODO: Disable the OFT CI for the time being.
       #       We will enable it after https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/issues/103


### PR DESCRIPTION
Fix the failure that we can't get up-spec
https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/actions/runs/13914084354/job/38934123380
![image](https://github.com/user-attachments/assets/4e6ff3e9-c4d0-446f-8097-1b9e7e9aefdd)
