### PR TITLE
Add workflow for checking latest spec compatibility

### DIFF
--- a/.env.oft-latest
+++ b/.env.oft-latest
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# shellcheck disable=SC2148,SC2034
+
+# The file patterns that specify the relevant parts of the latest uProtocol Specification
+# that this component is supposed to implement
+UP_SPEC_FILE_PATTERNS="up-spec/basics/uattributes.adoc up-spec/up-l1/README.adoc up-spec/up-l1/zenoh.adoc"
+
+# The file patterns that specify this component's resources which contain specification items
+# that cover the requirements
+COMPONENT_FILE_PATTERNS="Cargo.toml *.md .github examples src tests"
+
+OFT_FILE_PATTERNS="$UP_SPEC_FILE_PATTERNS $COMPONENT_FILE_PATTERNS"
+OFT_TAGS="_,TransportLayerImpl,TransportLayerImplPush"

--- a/.github/workflows/latest-up-spec-compatibility.yaml
+++ b/.github/workflows/latest-up-spec-compatibility.yaml
@@ -1,0 +1,88 @@
+# ********************************************************************************
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Verifies that this crate can be built using the uProtocol Core API from up-spec's main branch.
+# Also performs requirements tracing using OpenFastTrace. The job fails if any of the two
+# activities fail.
+
+name: Latest uP Spec Compatibility
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  requirements-tracing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Fast-Forward to HEAD revision of uProtocol Spec main branch
+        run: |
+          cd "${{ github.workspace }}/up-spec"
+          echo "Switching to up-spec/main branch ..."
+          git checkout main
+          echo "fast-forwarding to HEAD revision ..."
+          git pull
+          git status
+          cd "${{ github.workspace }}"
+
+      - name: "Determine OpenFastTrace file patterns from .env file"
+        uses: xom9ikk/dotenv@v2.3.0
+        with:
+          mode: "oft-latest"
+          load-mode: strict
+
+      # run OpenFastTrace first because the action will always succeed and produce
+      # a tracing report
+      - name: Run OpenFastTrace
+        id: run-oft
+        uses: eclipse-uprotocol/ci-cd/.github/actions/run-oft@main
+        with:
+          file-patterns: "${{ env.OFT_FILE_PATTERNS }}"
+          tags: "${{ env.OFT_TAGS_}}"
+
+      # now try to build and run the tests which may fail if incomaptible changes
+      # have been introduced into the uProtocol Core API
+      - uses: dtolnay/rust-toolchain@master
+        with: 
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Run tests
+        run: |
+          # Using nextest because it's faster than built-in test
+          cargo nextest run --all-features
+          # but it cannot execute doc tests
+          cargo test --doc --all-features
+
+      # This step will only be run if the tests in the previous step have succeeded.
+      # In that case, we use the exit code produced by the OFT run as the job's
+      # overall outcome. This means that the job fails if the tests run successfully
+      # but some of the requirements from up-spec are not covered.
+      - name: Determine exit status
+        env:
+          OFT_EXIT_CODE: ${{ steps.run-oft.outputs.oft-exit-code }}
+        run: |
+          exit $OFT_EXIT_CODE

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,7 +44,9 @@ jobs:
   coverage:
     uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@main
 
-  requirements-tracing:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
-    with:
-      oft-file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_COMPONENT_OPEN_FAST_TRACE_FILE_PATTERNS }}"
+  # disabled until up-spec repository has been tagged with the Zenoh transport specification containing
+  # OFT spec items
+  # current-spec-compliance:
+  #   uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
+  #   with:
+  #     env-file-suffix: "oft-current"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,10 @@ jobs:
 
   # TODO: Disable the OFT CI for the time being.
   #       We will enable it after https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/issues/103
-  #requirements-tracing:
-  #  uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
-  #  with:
-  #    oft-file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_COMPONENT_OPEN_FAST_TRACE_FILE_PATTERNS }}"
+  # current-spec-compliance:
+  #   uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
+  #   with:
+  #     env-file-suffix: "oft-current"
 
   tag_release_artifacts:
     # This only runs if this workflow is initiated via a tag-push with pattern 'v*'
@@ -54,7 +54,7 @@ jobs:
       - coverage
       # TODO: Disable the OFT CI for the time being.
       #       We will enable it after https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/issues/103
-      #- requirements-tracing
+      #- current-spec-compliance
     permissions: write-all
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adopted the way that up-spec reads in the OpenFastTrace configuration
params from an env file in the local workspace. This makes it easier
to adapt the file patterns and tags according to the evolvement of
up-spec. The former way of using GitHub repo variables for that
purpose was rather static and did not allow to use different sets of
patterns on different branches in the repo.