### PR TITLE
[#127] Process incoming messages on Zenoh's tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ chrono = "0.4.41"
 clap = { version = "4.5.40", features = ["derive"] }
 serde_json = "1.0.128"
 test-case = { version = "3.3" }
-tokio = { version = "1.45.1", default-features = false, features = ["signal"] }
+tokio = { version = "1.45.1", default-features = false, features = ["rt-multi-thread", "signal"] }
 tracing-subscriber = "0.3.19"
 up-rust = { version = "0.7.0", features = ["communication", "test-util"] }
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ Covers:
 ### Message Delivery
 `dsn~supported-message-delivery-methods~1`
 
-All messages are being received by means of subscribing to relevant Zenoh key patterns and delivering the messages to listeners that have been registered via `UPTransportZenoh::register_listener`.
+All messages are being received by means of registering callbacks for relevant Zenoh key patterns and delivering the messages to listeners that have been registered via `UPTransportZenoh::register_listener`.
+The callbacks dispatch all incoming messages to the registered listeners on the _same_ thread that the Zenoh runtime runs on.
 
 Rationale:
 The Zenoh protocol does not provide means to poll other nodes for messages but only supports the push model by means of clients subscribing to key patterns.
+
+The transport requires a tokio runtime to execute but does not make any implicit assumption regarding the availability and size of thread pools. This provides for flexibility regarding the environment that the transport can be deployed to but also requires application developers to take care when implementing message listeners, making sure to not block the transport's message callback when processing a dispatched message.
 
 Covers:
 - `req~utransport-delivery-methods~1`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,22 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+
+/*!
+This crate provides an implementation of the Eclipse Zenoh &trade; uProtocol Transport.
+The transport uses Zenoh's publish-subscribe mechanism to exchange messages. It is
+designed to be used in conjunction with the [up-rust](https://crates.io/crates/up_rust)
+crate, which provides the uProtocol message types and utilities.
+
+The transport is designed to run in the context of a [tokio `Runtime`] which
+needs to be configured outside of the transport according to the
+processing requirements of the use case at hand. The transport does
+not make any implicit assumptions about the number of threads available
+and does not spawn any threads itself.
+
+[tokio `Runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
+*/
+
 mod listener_registry;
 pub mod utransport;
 
@@ -27,6 +43,20 @@ use zenoh::Session;
 const UPROTOCOL_MAJOR_VERSION: u8 = 1;
 const DEFAULT_MAX_LISTENERS: usize = 100;
 
+/// An Eclipse Zenoh &trade; based uProtocol transport implementation.
+///
+/// The transport registers callbacks on the Zenoh runtime for listeners that
+/// are being registered using `up_rust::UTransport::register_listener`.
+///
+/// <div class="warning">
+///
+/// The registered listeners are being invoked sequentially on the **same thread**
+/// that the callback is being executed on. Implementers of listeners are therefore
+/// **strongly advised** to move non-trivial processing logic to **another/dedicated
+/// thread**, if necessary. Please refer to `subscriber` and `notification_receiver`
+/// in the examples directory for how this can be done.
+///
+/// </div>
 pub struct UPTransportZenoh {
     session: Arc<Session>,
     subscribers: ListenerRegistry,


### PR DESCRIPTION
Changed the transport to process incoming messages on the tokio runtime
that Zenoh's callback is running on. This provides for full flexibility
regarding the configuration of the tokio runtime and allows for more
efficient use of resources in scenarios where the transport is used
on a constrained environment.

Doc comments and examples have been updated to reflect this change and
to provide guidance on how to implement listeners that process messages
without blocking the incoming message callback.