### PR TITLE
Add integration tests for authorization

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,10 +28,7 @@ on:
     outputs:
       test_results_url:
         description: "URL of the test results artifact"
-        value: ${{ jobs.nextest.outputs.test_results_url }}
-      doctest_results_url:
-        description: "URL of the doctest results artifact"
-        value: ${{ jobs.doctest.outputs.test_results_url }}
+        value: ${{ jobs.test.outputs.test_results_url }}
   workflow_dispatch:
 
 concurrency:
@@ -120,12 +117,14 @@ jobs:
         with:
           args: "--cache --max-cache-age 1d --verbose --no-progress --exclude-path './target/' --exclude-path './up-spec/' -- './**/*.md' './**/*.rs' './**/*.adoc'"
 
-  nextest:
+  test:
+    # Subset of feature-combos, on only one OS - more complete testing in test-featurematrix.yaml
     outputs:
       test_results_url: ${{ steps.test_results.outputs.artifact-url }}
     runs-on: ubuntu-latest
-    env: 
-      NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+    strategy:
+      matrix:
+        feature-flags: ["", "--no-default-features", "--all-features"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -133,38 +132,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: Swatinem/rust-cache@v2
-      # Using nextest because it's faster than built-in test
-      - uses: taiki-e/install-action@nextest
-      - name: Run cargo nextest
+      - name: Run lib tests
         run: |
-          cargo nextest run --message-format libtest-json-plus > testresults.json
+          mkdir -p ${GITHUB_WORKSPACE}/target
+          RUSTC_BOOTSTRAP=1 cargo test --no-fail-fast --all-targets ${{ matrix.feature-flags }} -- -Z unstable-options --format junit --report-time > ${GITHUB_WORKSPACE}/target/lib-test-results.xml
+      - name: Run doc tests
+        run: |
+          RUSTC_BOOTSTRAP=1 cargo test --no-fail-fast --doc ${{ matrix.feature-flags }} -- -Z unstable-options --format junit --report-time > ${GITHUB_WORKSPACE}/target/doc-test-results.xml
+
       - name: Upload all-features test results artifact
         id: test_results
+        if: matrix.feature-flags == '--all-features'
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: testresults.json
-
-  doctest:
-    # Run doctests separately, as nextest doesn't yet (https://github.com/nextest-rs/nextest/issues/16)
-    outputs:
-      test_results_url: ${{ steps.doctest_results.outputs.artifact-url }}
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@master
-        with: 
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Run doc tests
-        run: |
-          RUSTC_BOOTSTRAP=1 cargo test --doc --all-features -- -Z unstable-options --format json --report-time > doctestresults--all-features.json
-      - name: Upload doctest results artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: doctest-results
-          path: doctestresults--all-features.json
+          # include all test result files
+          path: target/*-results.xml

--- a/.github/workflows/latest-up-spec-compatibility.yaml
+++ b/.github/workflows/latest-up-spec-compatibility.yaml
@@ -69,13 +69,9 @@ jobs:
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@nextest
       - name: Run tests
         run: |
-          # Using nextest because it's faster than built-in test
-          cargo nextest run --all-features
-          # but it cannot execute doc tests
-          cargo test --doc --all-features
+          cargo test --all-features
 
       # This step will only be run if the tests in the previous step have succeeded.
       # In that case, we use the exit code produced by the OFT run as the job's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,9 +1293,9 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1571,6 +1571,29 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "paste"
@@ -2044,6 +2067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2378,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2425,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "secrecy"
@@ -2508,6 +2555,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3133,6 +3205,7 @@ dependencies = [
  "clap",
  "protobuf",
  "serde_json",
+ "serial_test",
  "test-case",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ zenoh = { version = "1.5.0" }
 chrono = "0.4.41"
 clap = { version = "4.5.40", features = ["derive"] }
 serde_json = "1.0.128"
+serial_test = { version = "3.2.0" }
 test-case = { version = "3.3" }
 tokio = { version = "1.45.1", default-features = false, features = ["rt-multi-thread", "signal"] }
 tracing-subscriber = "0.3.19"

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ Covers:
 ### Authentication & Authorization
 `uman~auth-configuration~1`
 
-The transport provided by this crate can be configured with credentials that the transport will provide to the Zenoh router during connection establishment. A [_username_ and _password_](https://zenoh.io/docs/manual/user-password/) can be specified in the Zenoh config file that is passed into the `UPTransportZenoh::new` function to create a new transport instance.
+The transport provided by this crate can be configured with credentials that the transport will provide to the Zenoh router during connection establishment. A [_username_ and _password_](https://zenoh.io/docs/manual/user-password/) can be specified in the Zenoh config file that is passed into the `UPTransportZenohBuilder::with_config_file` function.
 
-Access to resources can be configured in the Zenoh config file by means of [Access Control Lists](https://zenoh.io/docs/manual/access-control/).
+Access to resources can be configured in the Zenoh (peer's or router's) config file by means of [Access Control Lists](https://zenoh.io/docs/manual/access-control/).
+The [authorization integration tests](./tests/authorization.rs) illustrate, how ACLs can be used to restrict a client's authority to put and subscribe to messages using corresponding rule sets.
 
 Covers:
-- `req~utransport-send-error-permission-denied~2`
+- `req~utransport-send-prevent-address-spoofing~1`
+- `req~utransport-registerlistener-prevent-unauthorized-access~1`
 
 ### Maximum number of listeners
 `uman~max-listeners-configuration~1`
@@ -116,15 +118,16 @@ Needs: impl, itest
 
 In general, uProtocol entities are only allowed to send messages on their own behalf. Certain specific uEntities acting as a uProtocol Streamer also need to send messages _on behalf of_ other uEntities in order to fulfill their original purpose of routing messages hence and forth between different transports. Making these authoritzation decisions requires the (proven) establishment of an _identity_ and its _authorities_.
 
-The Zenoh transport delegates all authorization decisions to the Zenoh router that the transport is configured to connect to. For this purpose, the transport supports configuration of credentials which are being used during connection establishment. The Zenoh router uses the provided credentials to establish the client's identity and its associated authorities. Whenever the uEntity sends a message via the router or registers a subscriber for a key pattern, the router verifies, if the client is authorized to publish using the key or receive messages matching the key pattern.
+The Zenoh transport delegates all authorization decisions to the Zenoh router (or peer) that the transport is configured to connect to. For this purpose, the transport supports configuration of credentials which are being used during connection establishment. The Zenoh router uses the provided credentials to establish the client's identity and its associated authorities. Whenever the uEntity sends a message via the router or registers a subscriber for a key pattern, the router verifies that the client is authorized to publish using the key or receive messages matching the key pattern.
 
 Rationale:
 The Zenoh transport is implemented as a library that is linked to the (custom) code that implements a uEntity's functionality. It is therefore not feasible to perform the authentication and authoritzation within the transport library code, because uEntities can not be forced to actually utilize one of uProtocol's transport libraries but may instead chooose to implement the binding to the transport protocol themselves.
 
 Covers:
-- `req~utransport-send-error-permission-denied~2`
+- `req~utransport-send-prevent-address-spoofing~1`
+- `req~utransport-registerlistener-prevent-unauthorized-access~1`
 
-Needs: impl, utest
+Needs: itest
 
 ## Change Log
 

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use protobuf::Message;
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::{debug, error, trace};
 use up_rust::{
     ComparableListener, UAttributes, UAttributesValidators, UCode, UListener, UMessage, UPriority,
     UStatus, UTransport, UUri,
@@ -125,6 +125,7 @@ impl UPTransportZenoh {
             // [impl->dsn~up-transport-zenoh-attributes-mapping~1]
             .attachment(attachment)
             .await
+            .inspect(|()| trace!("putting message with key: {zenoh_key}"))
             .map_err(|e| {
                 UStatus::fail_with_code(
                     UCode::INTERNAL,

--- a/tests/authorization.rs
+++ b/tests/authorization.rs
@@ -1,0 +1,315 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use std::{str::FromStr, sync::Arc, time::Duration};
+
+use tokio::sync::Notify;
+use up_rust::{MockUListener, UMessage, UMessageBuilder, UStatus, UTransport, UUri, UUID};
+use up_transport_zenoh::UPTransportZenoh;
+
+mod test_lib;
+
+const PEER_CONFIG: &str = r#"
+{
+    mode: "peer",
+    listen: {
+        endpoints: {
+            peer: ["tcp/127.0.0.1:15000"]
+        }
+    },
+    scouting: {
+        multicast: {
+            enabled: false
+        },
+        gossip: {
+            enabled: false
+        },
+    },
+    transport: {
+        auth: {
+            usrpwd: {
+                dictionary_file: "tests/users.txt"
+            }
+        }
+    }
+}"#;
+
+const PEER_ACL_CONFIG: &str = r#"
+{
+    "enabled": true,
+    "default_permission": "deny",
+    "rules": [
+        {
+            "id": "allowed_topics",
+            "permission": "allow",
+            "flows": ["ingress"],
+            "messages": ["put"],
+            "key_exprs": ["up/client/ABCD/0/1/A000/{}/{}/{}/{}/{}"]
+        },
+        {
+            "id": "allowed_subscriber_declarations",
+            "permission": "allow",
+            "flows": ["ingress"],
+            "messages": ["declare_subscriber"],
+            "key_exprs": ["up/*/*/*/*/*/service_provider/ABCD/0/1/**"]
+        },
+        {
+            "id": "allowed_rpc_requests",
+            "permission": "allow",
+            "flows": ["ingress", "egress"],
+            "messages": ["put"],
+            "key_exprs": ["up/*/*/*/*/0/service_provider/ABCD/0/1/**"]
+        },
+        {
+            "id": "allowed_rpc_responses",
+            "permission": "allow",
+            "flows": ["ingress"],
+            "messages": ["put"],
+            "key_exprs": ["up/service_provider/ABCD/0/1/*/*/*/*/*/0"]
+        }
+    ],
+    "subjects": [
+        {
+            "id": "authorized_clients",
+            "usernames": ["uprotocol"],
+        }
+    ],
+    "policies": [
+        {
+            "subjects": ["authorized_clients"],
+            "rules": [
+                "allowed_topics",
+                "allowed_subscriber_declarations",
+                "allowed_rpc_requests",
+                "allowed_rpc_responses"
+            ]
+        }
+    ]
+}
+"#;
+
+const CLIENT_CONFIG: &str = r#"
+{
+    mode: "client",
+    connect: {
+        endpoints: [
+            "tcp/127.0.0.1:15000"
+        ]
+    },
+    scouting: {
+        multicast: {
+            enabled: false
+        },
+        gossip: {
+            enabled: false
+        },
+    }
+}
+"#;
+
+const CLIENT_CREDENTIALS_AUTHORIZED: &str = r#"
+{
+    "usrpwd": {
+        "user": "uprotocol",
+        "password": "zenoh"
+    }
+}
+"#;
+const CLIENT_CREDENTIALS_UNAUTHORIZED: &str = r#"
+{
+    "usrpwd": {
+        "user": "attacker",
+        "password": "youwontknow"
+    }
+}
+"#;
+const AUTHORIZED_TOPIC: &str = "//client/ABCD/1/A000";
+const UNAUTHORIZED_TOPIC: &str = "//client/ABCD/1/BBBB";
+
+async fn create_peer_transport() -> Result<UPTransportZenoh, UStatus> {
+    let mut peer_config = zenoh::config::Config::from_json5(PEER_CONFIG)
+        .expect("Failed to load zenoh config from file");
+    peer_config
+        .insert_json5("access_control", PEER_ACL_CONFIG)
+        .expect("failed to set access control config");
+
+    test_lib::create_up_transport_zenoh("peer", Some(peer_config)).await
+}
+
+#[test_case::test_case(
+    UMessageBuilder::publish(UUri::from_str(AUTHORIZED_TOPIC)
+        .expect("invalid topic"))
+        .build()
+        .expect("Failed to build message"),
+        CLIENT_CREDENTIALS_AUTHORIZED => true;
+        "succeeds for authorized topic and client")]
+#[test_case::test_case(
+    UMessageBuilder::request(
+        UUri::from_str("//service_provider/ABCD/1/7100").expect("invalid method-to-invoke"),
+        UUri::from_str("//client/BBBB/1/0").expect("invalid reply-to address"),
+        5000
+    )
+    .build()
+    .expect("Failed to build message"),
+    CLIENT_CREDENTIALS_AUTHORIZED => true;
+    "succeeds for authorized method-to-invoke and client")]
+#[test_case::test_case(
+    UMessageBuilder::response(
+        UUri::from_str("//client/BBBB/1/0").expect("invalid reply-to address"),
+        UUID::build(),
+        UUri::from_str("//service_provider/ABCD/1/7100").expect("invalid invoked-method")
+    )
+    .build()
+    .expect("Failed to build message"),
+    CLIENT_CREDENTIALS_AUTHORIZED => true;
+    "succeeds for authorized invoked-method and client")]
+#[test_case::test_case(
+    UMessageBuilder::publish(UUri::from_str(AUTHORIZED_TOPIC).expect("invalid topic"))
+        .build()
+        .expect("Failed to build message"),
+    CLIENT_CREDENTIALS_UNAUTHORIZED => false;
+    "fails for authorized topic but unauthorized client")]
+#[test_case::test_case(
+    UMessageBuilder::publish(UUri::from_str(UNAUTHORIZED_TOPIC).expect("invalid topic"))
+        .build()
+        .expect("Failed to build message"),
+    CLIENT_CREDENTIALS_AUTHORIZED => false;
+    "fails for unauthorized topic but authorized client")]
+#[test_case::test_case(
+    UMessageBuilder::request(
+        UUri::from_str("//service_provider/AAAA/2/56").expect("invalid method-to-invoke"),
+        UUri::from_str("//client/BBBB/1/0").expect("invalid reply-to address"),
+        5000
+    )
+    .build()
+    .expect("Failed to build message"),
+    CLIENT_CREDENTIALS_AUTHORIZED => false;
+    "fails for unauthorized method-to-invoke but authorized client")]
+#[test_case::test_case(
+    UMessageBuilder::response(
+        UUri::from_str("//client/BBBB/1/0").expect("invalid reply-to address"),
+        UUID::build(),
+        UUri::from_str("//service_provider/AAAA/2/56").expect("invalid invoked-method")
+    )
+    .build()
+    .expect("Failed to build message"),
+    CLIENT_CREDENTIALS_AUTHORIZED => false;
+    "fails for unauthorized invoked-method but authorized client")]
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+// [itest->dsn~utransport-authorization~1]
+async fn test_send_message_to_peer(msg: UMessage, credentials: &str) -> bool {
+    test_lib::before_test();
+    let peer_transport = create_peer_transport()
+        .await
+        .expect("Failed to create peer transport");
+
+    let message_received = Arc::new(Notify::new());
+    let message_received_barrier = message_received.clone();
+    let mut mock_listener = MockUListener::new();
+    mock_listener.expect_on_receive().returning(move |_msg| {
+        message_received_barrier.notify_one();
+    });
+    let listener = Arc::new(mock_listener);
+    peer_transport
+        .register_listener(&UUri::any(), Some(&UUri::any()), listener.clone())
+        .await
+        .expect("Failed to register listener");
+
+    let mut client_config = zenoh::config::Config::from_json5(CLIENT_CONFIG)
+        .expect("Failed to load zenoh config from file");
+    client_config
+        .insert_json5("transport/auth", credentials)
+        .expect("failed to set auth config");
+
+    let client_transport = UPTransportZenoh::builder("client")
+        .expect("Failed to create transport builder")
+        .with_config(client_config)
+        .build()
+        .await
+        .expect("Failed to create transport");
+
+    assert!(
+        client_transport.send(msg).await.is_ok(),
+        "failed to send message"
+    );
+    tokio::time::timeout(Duration::from_millis(1000), message_received.notified())
+        .await
+        .is_ok()
+}
+
+#[test_case::test_case(
+    "//service_provider/ABCD/1/7100", CLIENT_CREDENTIALS_AUTHORIZED => true;
+    "succeeds for authorized method-to-invoke and client")]
+#[test_case::test_case(
+    "//service_provider/ABCD/1/7100", CLIENT_CREDENTIALS_UNAUTHORIZED => false;
+    "fails for authorized method-to-invoke but unauthorized client")]
+#[test_case::test_case(
+    "//other_service_provider/ABCD/1/7100", CLIENT_CREDENTIALS_AUTHORIZED => false;
+    "fails for unauthorized method-to-invoke but authorized client")]
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+// [itest->dsn~utransport-authorization~1]
+async fn test_subscribe_for_messages_from_peer(sink_filter_uri: &str, credentials: &str) -> bool {
+    test_lib::before_test();
+    let sink_filter = UUri::from_str(sink_filter_uri).expect("invalid sink filter");
+
+    let peer_transport = create_peer_transport()
+        .await
+        .expect("Failed to create peer transport");
+
+    let request_received = Arc::new(Notify::new());
+    let request_received_barrier = request_received.clone();
+    let mut mock_rpc_request_listener = MockUListener::new();
+    mock_rpc_request_listener
+        .expect_on_receive()
+        .returning(move |_msg| {
+            request_received_barrier.notify_one();
+        });
+    let rpc_request_listener = Arc::new(mock_rpc_request_listener);
+
+    let mut service_provider_config = zenoh::config::Config::from_json5(CLIENT_CONFIG)
+        .expect("Failed to load zenoh service provider config from file");
+    service_provider_config
+        .insert_json5("transport/auth", credentials)
+        .expect("failed to set auth config");
+    let service_provider_transport = UPTransportZenoh::builder("service_provider")
+        .expect("Failed to create service provider transport builder")
+        .with_config(service_provider_config)
+        .build()
+        .await
+        .map(Arc::new)
+        .expect("Failed to create service provider transport");
+
+    service_provider_transport
+        .register_listener(&UUri::any(), Some(&sink_filter), rpc_request_listener)
+        .await
+        .expect("Failed to register RPC handler");
+
+    // allow for the subscriber declaration to propagate through the network
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let reply_to_address =
+        UUri::from_str("//peer/BBBB/1/0").expect("Failed to create reply-to address URI");
+    let rpc_request = UMessageBuilder::request(sink_filter.clone(), reply_to_address, 5000)
+        .build()
+        .expect("Failed to build RPC request message");
+    peer_transport
+        .send(rpc_request)
+        .await
+        .expect("Failed to send RPC request");
+
+    tokio::time::timeout(Duration::from_millis(1000), request_received.notified())
+        .await
+        .is_ok()
+}

--- a/tests/blocking_callback.rs
+++ b/tests/blocking_callback.rs
@@ -47,7 +47,7 @@ async fn test_blocking_user_callback() {
     // create subscriber
     let topic = UUri::try_from_parts("vehicle", 0xaa0, 1, 0x8500).expect("invalid topic");
     let (tx, mut rx) = tokio::sync::mpsc::channel(5);
-    let transport = test_lib::create_up_transport_zenoh(topic.authority_name().as_str())
+    let transport = test_lib::create_up_transport_zenoh(topic.authority_name().as_str(), None)
         .await
         .expect("failed to create transport");
     transport

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -42,7 +42,7 @@ async fn register_listener_and_send(
     source_filter: &UUri,
     sink_filter: Option<&UUri>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let transport = test_lib::create_up_transport_zenoh(authority).await?;
+    let transport = test_lib::create_up_transport_zenoh(authority, None).await?;
 
     let notify = Arc::new(Notify::new());
     let listener = Arc::new(MessageHandler(umessage.clone(), notify.clone()));
@@ -269,7 +269,7 @@ async fn test_expired_rpc_request_message_is_not_delivered_to_listener() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unregister_listener_stops_processing_of_messages() {
-    let transport = test_lib::create_up_transport_zenoh("vehicle")
+    let transport = test_lib::create_up_transport_zenoh("vehicle", None)
         .await
         .expect("failed to create transport");
 
@@ -318,7 +318,7 @@ async fn test_unregister_listener_stops_processing_of_messages() {
 #[tokio::test(flavor = "multi_thread")]
 // [utest->dsn~utransport-registerlistener-listener-reuse~1]
 async fn test_same_listener_can_be_registered_for_multiple_filters() {
-    let transport = test_lib::create_up_transport_zenoh("vehicle")
+    let transport = test_lib::create_up_transport_zenoh("vehicle", None)
         .await
         .expect("failed to create transport");
 
@@ -374,7 +374,7 @@ async fn test_same_listener_can_be_registered_for_multiple_filters() {
 #[tokio::test(flavor = "multi_thread")]
 // [utest->dsn~utransport-registerlistener-number-of-listeners~1]
 async fn test_multiple_listeners_can_be_registered_for_the_same_filter() {
-    let transport = test_lib::create_up_transport_zenoh("vehicle")
+    let transport = test_lib::create_up_transport_zenoh("vehicle", None)
         .await
         .expect("failed to create transport");
 

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -24,9 +24,13 @@ pub fn before_test() {
 /// Will return `Err` if unable to create `UPTransportZenoh`
 pub async fn create_up_transport_zenoh(
     local_authority_name: &str,
+    config: Option<zenoh::config::Config>,
 ) -> Result<UPTransportZenoh, UStatus> {
     let builder = UPTransportZenoh::builder(local_authority_name).map_err(|e| {
         UStatus::fail_with_code(UCode::INVALID_ARGUMENT, format!("Invalid URI: {e}"))
     })?;
-    builder.build().await
+    builder
+        .with_config(config.unwrap_or_default())
+        .build()
+        .await
 }

--- a/tests/users.txt
+++ b/tests/users.txt
@@ -1,0 +1,2 @@
+uprotocol:zenoh
+attacker:youwontknow


### PR DESCRIPTION
Added integration tests for the authorization functionality of the
Zenoh transport. The tests cover scenarios for both authorized and
unauthorized clients, ensuring that the authorization mechanism
works as expected. The tests also verify that the access control
configuration is correctly applied, and that clients can only
publish and subscribe to topics they are authorized to access.