### PR TITLE
Don't check the dependencies when a PR is merged into main.

### DIFF
--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -14,8 +14,6 @@
 name: Check 3rd party dependencies
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     paths:
     - "Cargo.*"


### PR DESCRIPTION
As discussed in https://github.com/eclipse-uprotocol/ci-cd/issues/22, we don't do another check when a PR is merged into main.
This can help avoid too many requests to the license verification server.